### PR TITLE
Fix/add handshake logic

### DIFF
--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -37,7 +37,7 @@ class HttpTransporter implements Transporter
 
         // Guzzle returns headers as arrays
         $hdr = $response->getHeader('mcp-session-id');
-        if (!empty($hdr) && is_string($hdr[0])) {
+        if (! empty($hdr) && is_string($hdr[0])) {
             $this->sessionId = $hdr[0];
         }
     }

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -14,7 +14,7 @@ describe('HttpTransporter', function () {
     // Helper function to set up the transporter with a mocked client and session
     function createTransporterWithMockedSession($responseForInitialize = null)
     {
-        $transporter = new HttpTransporter();
+        $transporter = new HttpTransporter;
         $mockClient = Mockery::mock(Client::class);
 
         // Mock the initializeSession request
@@ -41,7 +41,7 @@ describe('HttpTransporter', function () {
     }
 
     test('preparePayload builds correct payload', function () {
-        $transporter = new HttpTransporter();
+        $transporter = new HttpTransporter;
         $method = new ReflectionMethod(HttpTransporter::class, 'preparePayload');
         $method->setAccessible(true);
 
@@ -54,7 +54,7 @@ describe('HttpTransporter', function () {
     });
 
     test('generateId returns numeric string within range', function () {
-        $transporter = new HttpTransporter();
+        $transporter = new HttpTransporter;
         $gen = new ReflectionMethod(HttpTransporter::class, 'generateId');
         $gen->setAccessible(true);
 
@@ -65,7 +65,7 @@ describe('HttpTransporter', function () {
     });
 
     test('getClientBaseConfig has default values', function () {
-        $transporter = new HttpTransporter();
+        $transporter = new HttpTransporter;
         $method = new ReflectionMethod(HttpTransporter::class, 'getClientBaseConfig');
         $method->setAccessible(true);
 


### PR DESCRIPTION
This pull request enhances the `HttpTransporter` class by introducing session management through an initialization handshake and improves the test suite for better coverage and maintainability. The key changes include adding a session initialization mechanism, updating the request method to include session headers, and refactoring tests to support session-based behavior.

### Core functionality updates:
* Added a private `initializeSession` method to perform a handshake and capture the MCP session ID, which is now required for all subsequent requests. (`src/Core/Transporters/HttpTransporter.php`, [src/Core/Transporters/HttpTransporter.phpR14-R60](diffhunk://#diff-ec3265c157908e20167cb60561e77ae4ed25b178ed98a8c326f0b497e3d4aea2R14-R60))
* Updated the `request` method to invoke `initializeSession` and include the session ID in the request headers. (`src/Core/Transporters/HttpTransporter.php`, [src/Core/Transporters/HttpTransporter.phpR14-R60](diffhunk://#diff-ec3265c157908e20167cb60561e77ae4ed25b178ed98a8c326f0b497e3d4aea2R14-R60))

### Test suite improvements:
* Introduced a helper function, `createTransporterWithMockedSession`, to simplify test setup by mocking the session initialization and client behavior. (`tests/Transporter/HttpTransporterTest.php`, [tests/Transporter/HttpTransporterTest.phpR13-R42](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42R13-R42))
* Refactored existing tests to use the new helper function, ensuring session-based headers and behavior are validated in all scenarios. (`tests/Transporter/HttpTransporterTest.php`, [[1]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L65-R146) [[2]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L113-R169) [[3]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L133-R199)