### PR TITLE
Add comprehensive transporter tests

### DIFF
--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -202,7 +202,7 @@ describe('HttpTransporter', function () {
         $mock = Mockery::mock(Client::class);
 
         $mock->shouldReceive('request')->once()
-            ->with('POST', '', Mockery::on(fn($o) => isset($o['json']['method']) && $o['json']['method'] === 'initialize'))
+            ->with('POST', '', Mockery::on(fn ($o) => isset($o['json']['method']) && $o['json']['method'] === 'initialize'))
             ->andReturn(new Response(200, ['mcp-session-id' => 'abc'], '{}'));
         $mock->shouldReceive('request')->once()
             ->with('POST', 'do', Mockery::on(function ($o) {
@@ -239,4 +239,3 @@ describe('HttpTransporter', function () {
             ->toThrow(Error::class);
     });
 });
-

--- a/tests/Transporter/StdioTransporterTest.php
+++ b/tests/Transporter/StdioTransporterTest.php
@@ -79,7 +79,7 @@ test('process failure throws TransporterRequestException', function () {
 });
 
 test('missing command throws InvalidArgumentException', function () {
-    $transporter = new StdioTransporter();
+    $transporter = new StdioTransporter;
 
     $this->expectException(InvalidArgumentException::class);
     $this->expectExceptionMessage('STDIO command is not defined');
@@ -103,4 +103,3 @@ test('createProcess respects root_path and timeout', function () {
     expect($process->getTimeout())->toBe(10.0);
     expect($process->getCommandLine())->toContain('php');
 });
-

--- a/tests/Transporter/StdioTransporterTest.php
+++ b/tests/Transporter/StdioTransporterTest.php
@@ -77,3 +77,30 @@ test('process failure throws TransporterRequestException', function () {
     $this->expectException(TransporterRequestException::class);
     $transporter->request('fail');
 });
+
+test('missing command throws InvalidArgumentException', function () {
+    $transporter = new StdioTransporter();
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage('STDIO command is not defined');
+
+    $transporter->request('foo');
+});
+
+test('createProcess respects root_path and timeout', function () {
+    $config = [
+        'command' => ['php', '-v'],
+        'root_path' => __DIR__,
+        'timeout' => 10,
+    ];
+    $transporter = new StdioTransporter($config);
+    $method = new ReflectionMethod(StdioTransporter::class, 'createProcess');
+    $method->setAccessible(true);
+
+    $process = $method->invoke($transporter, 'input');
+
+    expect($process->getWorkingDirectory())->toBe(__DIR__);
+    expect($process->getTimeout())->toBe(10.0);
+    expect($process->getCommandLine())->toContain('php');
+});
+


### PR DESCRIPTION
This pull request enhances test coverage for the `HttpTransporter` and `StdioTransporter` classes by adding new test cases to validate behavior under various conditions. The most important changes include testing session management in `HttpTransporter` and validating configuration handling in `StdioTransporter`.

### Tests for `HttpTransporter`:

* Added a test to verify that the `initializeSession` method correctly stores the session ID from response headers and includes it in subsequent requests (`tests/Transporter/HttpTransporterTest.php`).
* Added a test to ensure that a missing session header triggers an appropriate error when making requests (`tests/Transporter/HttpTransporterTest.php`).

### Tests for `StdioTransporter`:

* Added a test to verify that an `InvalidArgumentException` is thrown when a required command is missing (`tests/Transporter/StdioTransporterTest.php`).
* Added a test to validate that the `createProcess` method respects the `root_path` and `timeout` configuration options (`tests/Transporter/StdioTransporterTest.php`).
