### PR TITLE
Headers, new configs and fixes

### DIFF
--- a/config/mcp-client.php
+++ b/config/mcp-client.php
@@ -7,7 +7,7 @@ return [
             'base_url' => 'https://api.githubcopilot.com/mcp',
             'timeout' => 30,
             'token' => env('GITHUB_API_TOKEN', null),
-            'id_type' => 'string', // 'string' or 'int' - controls JSON-RPC id type (default: 'int')
+            'id_type' => 'int', // 'string' or 'int' - controls JSON-RPC id type (default: 'int')
             'headers' => [
                 // Add custom headers here - these will override default headers
             ],

--- a/config/mcp-client.php
+++ b/config/mcp-client.php
@@ -7,6 +7,10 @@ return [
             'base_url' => 'https://api.githubcopilot.com/mcp',
             'timeout' => 30,
             'token' => env('GITHUB_API_TOKEN', null),
+            'id_type' => 'string', // 'string' or 'int' - controls JSON-RPC id type (default: 'string')
+            'headers' => [
+                // Add custom headers here - these will override default headers
+            ],
         ],
         'npx_mcp_server' => [
             'type' => \Redberry\MCPClient\Enums\Transporters::STDIO,
@@ -20,5 +24,4 @@ return [
             'env' => [],
         ],
     ],
-
 ];

--- a/config/mcp-client.php
+++ b/config/mcp-client.php
@@ -7,7 +7,7 @@ return [
             'base_url' => 'https://api.githubcopilot.com/mcp',
             'timeout' => 30,
             'token' => env('GITHUB_API_TOKEN', null),
-            'id_type' => 'string', // 'string' or 'int' - controls JSON-RPC id type (default: 'string')
+            'id_type' => 'string', // 'string' or 'int' - controls JSON-RPC id type (default: 'int')
             'headers' => [
                 // Add custom headers here - these will override default headers
             ],
@@ -22,6 +22,8 @@ return [
             'timeout' => 30,
             'cwd' => base_path(),
             'env' => [],
+            'startup_delay' => 50, // milliseconds - delay after process start (default: 50)
+            'poll_interval' => 10, // milliseconds - polling interval for response (default: 10)
         ],
     ],
 ];

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -135,7 +135,7 @@ class HttpTransporter implements Transporter
         }
 
         $clientConfig = [
-            'base_uri' => rtrim($baseUri, '/').'/',    // ensure trailing slash
+            'base_uri' => $baseUri,
             'headers' => $headers,
         ];
 

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -11,7 +11,7 @@ class HttpTransporter implements Transporter
 {
     private GuzzleClient $client;
 
-    // Some servers doesn't return session ID, so we default to "1"
+    // Some servers don't return session ID, so we default to "1"
     private string $sessionId = '1';
 
     private bool $initialized = false;
@@ -95,7 +95,7 @@ class HttpTransporter implements Transporter
     {
         $id = random_int(1, 1000000);
 
-        // Check if the config specifies id_type (default is 'string')
+        // Check if the config specifies id_type (default is 'int')
         $idType = $this->config['id_type'] ?? 'int';
 
         return $idType === 'integer' || $idType === 'int' ? $id : (string) $id;

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -12,7 +12,7 @@ class HttpTransporter implements Transporter
     private GuzzleClient $client;
 
     // Some servers doesn't return session ID, so we default to "1"
-    private string $sessionId = "1";
+    private string $sessionId = '1';
 
     private bool $initialized = false;
 
@@ -62,7 +62,7 @@ class HttpTransporter implements Transporter
 
         try {
             // No action needed, we always send to the base URL
-            $response = $this->client->request('POST', "", [
+            $response = $this->client->request('POST', '', [
                 'json' => $payload,
                 'timeout' => $this->config['timeout'] ?? 30,
                 'headers' => [
@@ -94,10 +94,10 @@ class HttpTransporter implements Transporter
     private function generateId(): string|int
     {
         $id = random_int(1, 1000000);
-        
+
         // Check if the config specifies id_type (default is 'string')
         $idType = $this->config['id_type'] ?? 'int';
-        
+
         return $idType === 'integer' || $idType === 'int' ? $id : (string) $id;
     }
 

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -11,7 +11,10 @@ class HttpTransporter implements Transporter
 {
     private GuzzleClient $client;
 
-    private string $sessionId;
+    // Some servers doesn't return session ID, so we default to "1"
+    private string $sessionId = "1";
+
+    private bool $initialized = false;
 
     /**
      * @throws GuzzleException
@@ -29,6 +32,10 @@ class HttpTransporter implements Transporter
      */
     private function initializeSession(): void
     {
+        if ($this->initialized) {
+            return;
+        }
+
         $payload = $this->preparePayload('initialize');
         $response = $this->client->request('POST', '', [
             'json' => $payload,
@@ -40,6 +47,8 @@ class HttpTransporter implements Transporter
         if (! empty($hdr)) {
             $this->sessionId = $hdr[0];
         }
+
+        $this->initialized = true;
     }
 
     /**
@@ -52,7 +61,8 @@ class HttpTransporter implements Transporter
         $payload = $this->preparePayload($action, $params);
 
         try {
-            $response = $this->client->request('POST', $action, [
+            // No action needed, we always send to the base URL
+            $response = $this->client->request('POST', "", [
                 'json' => $payload,
                 'timeout' => $this->config['timeout'] ?? 30,
                 'headers' => [
@@ -81,9 +91,14 @@ class HttpTransporter implements Transporter
         }
     }
 
-    private function generateId(): string
+    private function generateId(): string|int
     {
-        return (string) random_int(1, 1000000);
+        $id = random_int(1, 1000000);
+        
+        // Check if the config specifies id_type (default is 'string')
+        $idType = $this->config['id_type'] ?? 'int';
+        
+        return $idType === 'integer' || $idType === 'int' ? $id : (string) $id;
     }
 
     private function preparePayload(string $action, ?array $params = null)
@@ -103,17 +118,26 @@ class HttpTransporter implements Transporter
         $baseUri = $this->config['base_url'] ?? 'http://localhost/api';
         $token = $this->config['token'] ?? null;
 
-        $clientConfig = [
-            'base_uri' => rtrim($baseUri, '/').'/',    // ensure trailing slash
-            'headers' => [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ],
+        // Start with default headers
+        $headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
         ];
 
+        // Add Authorization header if token is provided
         if ($token) {
-            $clientConfig['headers']['Authorization'] = "Bearer {$token}";
+            $headers['Authorization'] = "Bearer {$token}";
         }
+
+        // Merge custom headers from config (config headers have higher priority)
+        if (isset($this->config['headers']) && is_array($this->config['headers'])) {
+            $headers = array_merge($headers, $this->config['headers']);
+        }
+
+        $clientConfig = [
+            'base_uri' => rtrim($baseUri, '/').'/',    // ensure trailing slash
+            'headers' => $headers,
+        ];
 
         return $clientConfig;
     }

--- a/src/Core/Transporters/StdioTransporter.php
+++ b/src/Core/Transporters/StdioTransporter.php
@@ -21,6 +21,10 @@ class StdioTransporter implements Transporter
 
     private const DEFAULT_TIMEOUT = 3;
 
+    private const DEFAULT_STARTUP_DELAY = 50; // milliseconds
+
+    private const DEFAULT_POLL_INTERVAL = 10; // milliseconds
+
     /** @var list<string> */
     private array $command;
 
@@ -55,7 +59,8 @@ class StdioTransporter implements Transporter
 
         try {
             $this->process->start();
-            usleep(200_000);
+            $startupDelay = $this->config['startup_delay'] ?? self::DEFAULT_STARTUP_DELAY;
+            usleep($startupDelay * 1000); // convert milliseconds to microseconds
         } catch (\Throwable $e) {
             $this->cleanup();
             throw new TransporterRequestException(
@@ -240,7 +245,8 @@ class StdioTransporter implements Transporter
                 }
             }
 
-            usleep(50_000);
+            $pollInterval = $this->config['poll_interval'] ?? self::DEFAULT_POLL_INTERVAL;
+            usleep($pollInterval * 1000); // convert milliseconds to microseconds
         }
 
         throw new TransporterRequestException(

--- a/src/Core/Transporters/StdioTransporter.php
+++ b/src/Core/Transporters/StdioTransporter.php
@@ -21,9 +21,9 @@ class StdioTransporter implements Transporter
 
     private const DEFAULT_TIMEOUT = 3;
 
-    private const DEFAULT_STARTUP_DELAY = 50; // milliseconds
+    private const DEFAULT_STARTUP_DELAY = 100; // milliseconds
 
-    private const DEFAULT_POLL_INTERVAL = 10; // milliseconds
+    private const DEFAULT_POLL_INTERVAL = 20; // milliseconds
 
     /** @var list<string> */
     private array $command;

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -88,7 +88,7 @@ describe('HttpTransporter', function () {
 
         $config = $method->invoke($transporter);
 
-        expect($config['base_uri'])->toBe('http://localhost/api/');
+        expect($config['base_uri'])->toBe('http://localhost/api');
         expect($config['headers'])->toHaveKey('Accept', 'application/json');
         expect($config['headers'])->toHaveKey('Content-Type', 'application/json');
         expect(array_key_exists('Authorization', $config['headers']))->toBeFalse();
@@ -104,7 +104,7 @@ describe('HttpTransporter', function () {
 
         $config = $method->invoke($transporter);
 
-        expect($config['base_uri'])->toBe('http://example.com/api/');
+        expect($config['base_uri'])->toBe('http://example.com/api');
         expect($config['headers'])->toHaveKey('Authorization', 'Bearer secret-token');
     });
 
@@ -171,7 +171,7 @@ describe('HttpTransporter', function () {
 
         $config = $method->invoke($transporter);
 
-        expect($config['base_uri'])->toBe('https://api.example.com/');
+        expect($config['base_uri'])->toBe('https://api.example.com');
         expect($config['headers'])->toHaveKey('Authorization', 'Bearer secret-token');
         expect($config['headers'])->toHaveKey('X-Custom-Header', 'custom-value');
         expect($config['headers'])->toHaveKey('Accept', 'application/vnd.api+json');

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -46,17 +46,17 @@ describe('HttpTransporter', function () {
         expect($payload['jsonrpc'])->toBe('2.0');
         expect($payload['method'])->toBe('testMethod');
         expect($payload['params'])->toEqual(['param1', 2]);
-        expect(is_string($payload['id']) && preg_match('/^\d+$/', $payload['id']))->toBeTrue();
+        expect((is_string($payload['id']) || is_int($payload['id'])) && preg_match('/^\d+$/', (string) $payload['id']))->toBeTrue();
     });
 
-    test('generateId returns numeric string within range', function () {
+    test('generateId returns numeric within range', function () {
         $transporter = new HttpTransporter;
         $gen = new ReflectionMethod(HttpTransporter::class, 'generateId');
         $gen->setAccessible(true);
 
         $id = $gen->invoke($transporter);
 
-        expect(is_string($id))->toBeTrue();
+        expect(is_string($id) || is_int($id))->toBeTrue();
         expect(preg_match('/^\d+$/', $id) === 1 && ((int) $id >= 1 && (int) $id <= 1000000))->toBeTrue();
     });
 
@@ -71,14 +71,14 @@ describe('HttpTransporter', function () {
         expect($id >= 1 && $id <= 1000000)->toBeTrue();
     });
 
-    test('generateId returns string by default', function () {
+    test('generateId returns int by default', function () {
         $transporter = new HttpTransporter;
         $gen = new ReflectionMethod(HttpTransporter::class, 'generateId');
         $gen->setAccessible(true);
 
         $id = $gen->invoke($transporter);
 
-        expect(is_string($id))->toBeTrue();
+        expect(is_int($id))->toBeTrue();
     });
 
     test('getClientBaseConfig has default values', function () {

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -57,7 +57,7 @@ describe('HttpTransporter', function () {
         $id = $gen->invoke($transporter);
 
         expect(is_string($id) || is_int($id))->toBeTrue();
-        expect(preg_match('/^\d+$/', $id) === 1 && ((int) $id >= 1 && (int) $id <= 1000000))->toBeTrue();
+        expect(preg_match('/^\d+$/', (string) $id) === 1 && ((int) $id >= 1 && (int) $id <= 1000000))->toBeTrue();
     });
 
     test('generateId returns integer when id_type is integer', function () {


### PR DESCRIPTION
This pull request adds configurability and improves robustness for both HTTP and Stdio transporters, as well as expands and updates the test suite to cover new behaviors. The main changes include support for custom HTTP headers, configurable JSON-RPC ID types, and new timing options for the Stdio transporter. Tests have been updated and extended to verify these new features.

**Transporter configuration improvements**

* Added support for custom HTTP headers and configurable JSON-RPC ID type (`string` or `int`) in `config/mcp-client.php` and the `HttpTransporter` class, allowing more flexible integration with different APIs. [[1]](diffhunk://#diff-fa01f03796349acbb30ef4d1203956bc5c0218ce50fb525a1cd3907b7e4f6de7R10-R13) [[2]](diffhunk://#diff-ec3265c157908e20167cb60561e77ae4ed25b178ed98a8c326f0b497e3d4aea2L106-R141)
* Introduced `startup_delay` and `poll_interval` configuration options for the Stdio transporter, making process startup and response polling timing adjustable. [[1]](diffhunk://#diff-fa01f03796349acbb30ef4d1203956bc5c0218ce50fb525a1cd3907b7e4f6de7R25-L23) [[2]](diffhunk://#diff-5549eeb64bff84027527b4eee4514565c857fa4742cc96af6d4d3cc5e067990dR24-R27)

**Code robustness and logic fixes**

* Improved session initialization logic in `HttpTransporter` by adding an `initialized` flag to prevent repeated initialization, and defaulting `sessionId` to `"1"` if not provided by the server. [[1]](diffhunk://#diff-ec3265c157908e20167cb60561e77ae4ed25b178ed98a8c326f0b497e3d4aea2L14-R17) [[2]](diffhunk://#diff-ec3265c157908e20167cb60561e77ae4ed25b178ed98a8c326f0b497e3d4aea2R35-R38) [[3]](diffhunk://#diff-ec3265c157908e20167cb60561e77ae4ed25b178ed98a8c326f0b497e3d4aea2R50-R51)
* Changed HTTP requests to always use the base URL (empty action path), ensuring consistent endpoint usage and simplifying request logic.

**ID generation enhancements**

* Updated `generateId` in `HttpTransporter` to support both integer and string types based on configuration, with tests verifying correct behavior for all cases. [[1]](diffhunk://#diff-ec3265c157908e20167cb60561e77ae4ed25b178ed98a8c326f0b497e3d4aea2L84-R101) [[2]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L53-R83)

**Test suite updates**

* Refactored and expanded tests in `HttpTransporterTest.php` to cover custom header merging, header overrides, ID type configuration, and new transporter timing options. [[1]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L20-L28) [[2]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42R31-R35) [[3]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42R111-R187)
* Updated all HTTP transporter request tests to expect the base URL instead of action-based endpoints. [[1]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L119-R206) [[2]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L138-R225) [[3]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L161-R248) [[4]](diffhunk://#diff-349a8e6a1ad1250a229212584bbf56710c84acf97c1097e1e13c0ebc78c64a42L183-R270)