### PR TITLE
Add MCP Streamable HTTP transport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
 # Changelog
 
 All notable changes to `mcp-client-laravel` will be documented in this file.
+
+## Unreleased
+
+### Added
+
+- HTTP transporter now implements MCP's Streamable HTTP transport (2025-03-26): every request advertises `Accept: application/json, text/event-stream` and content-negotiates with the server, parsing either a single JSON response or an SSE stream of JSON-RPC messages.
+- New `SseStreamParser` helper for decoding `text/event-stream` responses.
+- Optional `?callable $onEvent` parameter on `MCPClient::callTool()` and `MCPClient::readResource()` (and on the underlying `Transporter::request()` interface) for observing intermediate streamed events.
+- `HttpTransporter` constructor now accepts an optional Guzzle `ClientInterface` for dependency injection.
+
+### Changed
+
+- `composer.json` now explicitly requires `guzzlehttp/guzzle` and `psr/http-message`, which the HTTP transporter has always relied on transitively.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ return [
 -   `timeout`: Request timeout in seconds
 -   `token`: Authentication token (if required)
 
+The HTTP transporter implements MCP's [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). Each request advertises `Accept: application/json, text/event-stream`, and the server decides — per call — whether to respond with a single JSON object or an SSE stream of JSON-RPC messages. The client handles both transparently: you always receive the final `result`, regardless of how the server chose to deliver it.
+
 #### STDIO Transporter
 
 -   `type`: Set to `Redberry\MCPClient\Enums\Transporters::STDIO` for STDIO connections
@@ -151,7 +153,7 @@ $mappedTools = $client->tools()->map(function ($tool) {
 The `callTool` method is used to execute specific tool. Here is the signature:
 
 ```php
-public function callTool(string $toolName, mixed $params = []): mixed;
+public function callTool(string $toolName, mixed $params = [], ?callable $onEvent = null): mixed;
 ```
 
 Example:
@@ -168,12 +170,25 @@ $result = $client->callTool('create_entities', [
 ]);
 ```
 
-### Read Resources
+#### Observing streamed events
 
-The `readResource` method is used to retrieve the resource by the `uri`.
+When the server responds with an SSE stream, you can pass an `$onEvent` callback to observe each intermediate JSON-RPC message (progress notifications, partial results, log entries) as it arrives. The call still blocks until the final `result` is returned.
 
 ```php
-public function readResource(string $uri): mixed;
+$result = $client->callTool('long_running_tool', $args, function (array $event) {
+    // $event is a decoded JSON-RPC message: notification, progress, or final result
+    logger()->debug('mcp event', $event);
+});
+```
+
+The callback is invoked zero times if the server returns a single JSON response, so it is safe to pass unconditionally.
+
+### Read Resources
+
+The `readResource` method is used to retrieve the resource by the `uri`. It accepts the same optional `$onEvent` callback as `callTool`.
+
+```php
+public function readResource(string $uri, ?callable $onEvent = null): mixed;
 ```
 
 Example:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ $result = $client->callTool('create_entities', [
 
 #### Observing streamed events
 
-When the server responds with an SSE stream, you can pass an `$onEvent` callback to observe each intermediate JSON-RPC message (progress notifications, partial results, log entries) as it arrives. The call still blocks until the final `result` is returned.
+When the server responds with an SSE stream, you can pass an `$onEvent` callback to observe every decoded JSON-RPC message — progress notifications, partial results, log entries, and the final result-bearing message — as each one arrives. The call still blocks until the final `result` is returned.
 
 ```php
 $result = $client->callTool('long_running_tool', $args, function (array $event) {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,10 @@
     ],
     "require": {
         "php": "^8.3||^8.4",
-        "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "guzzlehttp/guzzle": "^7.5",
+        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "psr/http-message": "^1.1||^2.0",
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.14",

--- a/config/mcp-client.php
+++ b/config/mcp-client.php
@@ -1,9 +1,11 @@
 <?php
 
+use Redberry\MCPClient\Enums\Transporters;
+
 return [
     'servers' => [
         'github' => [
-            'type' => \Redberry\MCPClient\Enums\Transporters::HTTP,
+            'type' => Transporters::HTTP,
             'base_url' => 'https://api.githubcopilot.com/mcp',
             'timeout' => 30,
             'token' => env('GITHUB_API_TOKEN', null),
@@ -13,7 +15,7 @@ return [
             ],
         ],
         'npx_mcp_server' => [
-            'type' => \Redberry\MCPClient\Enums\Transporters::STDIO,
+            'type' => Transporters::STDIO,
             'command' => [
                 'npx',
                 '-y',

--- a/src/Contracts/MCPClient.php
+++ b/src/Contracts/MCPClient.php
@@ -10,7 +10,7 @@ interface MCPClient
 
     public function resources();
 
-    public function callTool(string $toolName, mixed $params = []): mixed;
+    public function callTool(string $toolName, mixed $params = [], ?callable $onEvent = null): mixed;
 
-    public function readResource(string $uri): mixed;
+    public function readResource(string $uri, ?callable $onEvent = null): mixed;
 }

--- a/src/Core/Http/SseStreamParser.php
+++ b/src/Core/Http/SseStreamParser.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redberry\MCPClient\Core\Http;
+
+use JsonException;
+use Psr\Http\Message\StreamInterface;
+use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
+
+/**
+ * Parses an MCP Streamable HTTP `text/event-stream` response.
+ *
+ * Each Server-Sent Event carries a complete JSON-RPC message. Any event
+ * with a `result` field is treated as the final response; intermediate
+ * events (notifications, progress) are forwarded to the optional
+ * `$onEvent` callback so callers can observe partial output.
+ */
+class SseStreamParser
+{
+    private const READ_BYTES = 8192;
+
+    private const DONE_SENTINEL = '[DONE]';
+
+    /**
+     * Read the stream to completion and return the final JSON-RPC `result`.
+     *
+     * @param  callable(array $event):void|null  $onEvent  Invoked for every decoded event message.
+     *
+     * @throws TransporterRequestException If the stream ends without a result, or any event carries a JSON-RPC error.
+     * @throws JsonException
+     */
+    public static function parse(StreamInterface $stream, ?callable $onEvent = null): array
+    {
+        $buffer = '';
+        $current = self::emptyEvent();
+        $final = null;
+
+        while (! $stream->eof()) {
+            $chunk = $stream->read(self::READ_BYTES);
+            if ($chunk === '') {
+                continue;
+            }
+
+            $buffer .= $chunk;
+            self::drainLines($buffer, $current, $final, $onEvent);
+        }
+
+        // Force-flush a trailing line and/or event that lacks the SSE terminator.
+        if ($buffer !== '' || $current['data'] !== '') {
+            $buffer .= "\n\n";
+            self::drainLines($buffer, $current, $final, $onEvent);
+        }
+
+        if ($final === null) {
+            throw new TransporterRequestException('SSE stream ended without a JSON-RPC result.');
+        }
+
+        return $final;
+    }
+
+    /**
+     * Drain complete (newline-terminated) lines from the buffer, updating the
+     * pending event state and recording the latest result-bearing payload.
+     *
+     * @param  callable(array $event):void|null  $onEvent
+     *
+     * @throws TransporterRequestException
+     * @throws JsonException
+     */
+    private static function drainLines(string &$buffer, array &$current, ?array &$final, ?callable $onEvent): void
+    {
+        while (($pos = strpos($buffer, "\n")) !== false) {
+            $line = rtrim(substr($buffer, 0, $pos), "\r");
+            $buffer = substr($buffer, $pos + 1);
+
+            if ($line === '') {
+                $payload = self::dispatch($current, $onEvent);
+                if ($payload !== null) {
+                    $final = $payload;
+                }
+                $current = self::emptyEvent();
+
+                continue;
+            }
+
+            if (str_starts_with($line, ':')) {
+                continue; // SSE comment
+            }
+
+            if (str_starts_with($line, 'event:')) {
+                $current['event'] = trim(substr($line, 6));
+
+                continue;
+            }
+
+            if (str_starts_with($line, 'data:')) {
+                $piece = ltrim(substr($line, 5), ' ');
+                $current['data'] .= $current['data'] === '' ? $piece : "\n".$piece;
+            }
+        }
+    }
+
+    /**
+     * Decode an event's `data` payload and surface it. Returns the result-bearing
+     * payload (which becomes the new "final"), or null if this event has no result.
+     *
+     * @throws TransporterRequestException
+     * @throws JsonException
+     */
+    private static function dispatch(array $event, ?callable $onEvent): ?array
+    {
+        $data = trim($event['data']);
+        if ($data === '' || $data === self::DONE_SENTINEL) {
+            return null;
+        }
+
+        $decoded = json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+
+        if (! \is_array($decoded)) {
+            return null;
+        }
+
+        if (isset($decoded['error'])) {
+            throw new TransporterRequestException(
+                "JSON-RPC error: {$decoded['error']['message']}",
+                (int) ($decoded['error']['code'] ?? 0),
+            );
+        }
+
+        if ($onEvent !== null) {
+            $onEvent($decoded);
+        }
+
+        if (\array_key_exists('result', $decoded)) {
+            return \is_array($decoded['result']) ? $decoded['result'] : $decoded;
+        }
+
+        return null;
+    }
+
+    private static function emptyEvent(): array
+    {
+        return ['event' => null, 'data' => ''];
+    }
+}

--- a/src/Core/Http/SseStreamParser.php
+++ b/src/Core/Http/SseStreamParser.php
@@ -11,10 +11,11 @@ use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
 /**
  * Parses an MCP Streamable HTTP `text/event-stream` response.
  *
- * Each Server-Sent Event carries a complete JSON-RPC message. Any event
- * with a `result` field is treated as the final response; intermediate
- * events (notifications, progress) are forwarded to the optional
- * `$onEvent` callback so callers can observe partial output.
+ * Each Server-Sent Event carries a complete JSON-RPC message. The optional
+ * `$onEvent` callback is invoked for every decoded message — notifications,
+ * progress updates, and the final result-bearing event alike — so callers
+ * can observe the full stream. The result-bearing event also drives the
+ * value returned by `parse()`.
  */
 class SseStreamParser
 {
@@ -25,7 +26,8 @@ class SseStreamParser
     /**
      * Read the stream to completion and return the final JSON-RPC `result`.
      *
-     * @param  callable(array $event):void|null  $onEvent  Invoked for every decoded event message.
+     * @param  callable(array $event):void|null  $onEvent  Invoked for every decoded event message,
+     *                                                     including the final result-bearing one.
      *
      * @throws TransporterRequestException If the stream ends without a result, or any event carries a JSON-RPC error.
      * @throws JsonException

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -5,28 +5,29 @@ namespace Redberry\MCPClient\Core\Transporters;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface as GuzzleClient;
 use GuzzleHttp\Exception\GuzzleException;
+use JsonException;
+use Psr\Http\Message\ResponseInterface;
 use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
+use Redberry\MCPClient\Core\Http\SseStreamParser;
 
 class HttpTransporter implements Transporter
 {
     private GuzzleClient $client;
 
-    // Some servers don't return session ID, so we default to "1"
-    private string $sessionId = '1';
+    private ?string $sessionId = null;
 
     private bool $initialized = false;
 
-    /**
-     * @throws GuzzleException
-     */
-    public function __construct(private array $config = [])
-    {
-        $this->initializeClient();
+    public function __construct(
+        private array $config = [],
+        ?GuzzleClient $client = null,
+    ) {
+        $this->client = $client ?? new Client($this->getClientBaseConfig());
     }
 
     /**
-     * Perform the “initialize” handshake and capture the MCP session ID.
-     * Call this *once* before you start sending other RPCs.
+     * Perform the "initialize" handshake and capture the MCP session id.
+     * Called once before the first user-issued request.
      *
      * @throws GuzzleException
      */
@@ -40,9 +41,10 @@ class HttpTransporter implements Transporter
         $response = $this->client->request('POST', '', [
             'json' => $payload,
             'timeout' => $this->config['timeout'] ?? 30,
+            'stream' => true,
+            'headers' => $this->buildRequestHeaders(),
         ]);
 
-        // Guzzle returns headers as arrays
         $hdr = $response->getHeader('mcp-session-id');
         if (! empty($hdr)) {
             $this->sessionId = $hdr[0];
@@ -54,63 +56,93 @@ class HttpTransporter implements Transporter
     /**
      * @throws TransporterRequestException
      * @throws GuzzleException
+     * @throws JsonException
      */
-    public function request(string $action, ?array $params = null): array
+    public function request(string $action, ?array $params = null, ?callable $onEvent = null): array
     {
         $this->initializeSession();
         $payload = $this->preparePayload($action, $params);
 
         try {
-            // No action needed, we always send to the base URL
             $response = $this->client->request('POST', '', [
                 'json' => $payload,
                 'timeout' => $this->config['timeout'] ?? 30,
-                'headers' => [
-                    'mcp-session-id' => $this->sessionId,
-                ],
+                'stream' => true,
+                'headers' => $this->buildRequestHeaders(),
             ]);
-            $body = (string) $response->getBody();
-            $data = json_decode($body, true);
 
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new TransporterRequestException('Invalid JSON response: '.json_last_error_msg());
-            }
-
-            if (isset($data['error'])) {
-                throw new TransporterRequestException("JSON-RPC error: {$data['error']['message']}",
-                    $data['error']['code']);
-            }
-
-            return $data['result'] ?? $data;
+            return $this->parseResponse($response, $onEvent);
         } catch (GuzzleException $e) {
             throw new TransporterRequestException(
                 "HTTP error for {$action}: {$e->getMessage()}",
-                $e->getCode(),
+                (int) $e->getCode(),
                 $e
             );
         }
+    }
+
+    /**
+     * @throws TransporterRequestException
+     * @throws JsonException
+     */
+    private function parseResponse(ResponseInterface $response, ?callable $onEvent): array
+    {
+        $contentType = strtolower(trim(explode(';', $response->getHeaderLine('Content-Type'))[0]));
+
+        if ($contentType === 'text/event-stream') {
+            return SseStreamParser::parse($response->getBody(), $onEvent);
+        }
+
+        $body = (string) $response->getBody();
+
+        try {
+            $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new TransporterRequestException('Invalid JSON response: '.$e->getMessage(), 0, $e);
+        }
+
+        if (isset($data['error'])) {
+            throw new TransporterRequestException(
+                "JSON-RPC error: {$data['error']['message']}",
+                (int) ($data['error']['code'] ?? 0),
+            );
+        }
+
+        return $data['result'] ?? $data;
+    }
+
+    /**
+     * Per-request headers. Always advertises both content types so the server
+     * can content-negotiate between a single JSON response and an SSE stream.
+     */
+    private function buildRequestHeaders(): array
+    {
+        $headers = ['Accept' => 'application/json, text/event-stream'];
+
+        if ($this->sessionId !== null) {
+            $headers['mcp-session-id'] = $this->sessionId;
+        }
+
+        return $headers;
     }
 
     private function generateId(): string|int
     {
         $id = random_int(1, 1000000);
 
-        // Check if the config specifies id_type (default is 'int')
         $idType = $this->config['id_type'] ?? 'int';
 
         return $idType === 'integer' || $idType === 'int' ? $id : (string) $id;
     }
 
-    private function preparePayload(string $action, ?array $params = null)
+    private function preparePayload(string $action, ?array $params = null): array
     {
-        $payload = [
+        return [
             'jsonrpc' => '2.0',
             'method' => $action,
-            'params' => $params,
+            'params' => $params ?? (object) [],
             'id' => $this->generateId(),
         ];
-
-        return $payload;
     }
 
     private function getClientBaseConfig(): array
@@ -118,38 +150,22 @@ class HttpTransporter implements Transporter
         $baseUri = $this->config['base_url'] ?? 'http://localhost/api';
         $token = $this->config['token'] ?? null;
 
-        // Start with default headers
         $headers = [
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
         ];
 
-        // Add Authorization header if token is provided
         if ($token) {
             $headers['Authorization'] = "Bearer {$token}";
         }
 
-        // Merge custom headers from config (config headers have higher priority)
-        if (isset($this->config['headers']) && is_array($this->config['headers'])) {
+        if (isset($this->config['headers']) && \is_array($this->config['headers'])) {
             $headers = array_merge($headers, $this->config['headers']);
         }
 
-        $clientConfig = [
+        return [
             'base_uri' => $baseUri,
             'headers' => $headers,
         ];
-
-        return $clientConfig;
-    }
-
-    /**
-     * @throws GuzzleException
-     */
-    private function initializeClient()
-    {
-        $clientConfig = $this->getClientBaseConfig();
-
-        // finally, instantiate the client
-        $this->client = new Client($clientConfig);
     }
 }

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -29,7 +29,7 @@ class HttpTransporter implements Transporter
      * Perform the "initialize" handshake and capture the MCP session id.
      * Called once before the first user-issued request.
      *
-     * @throws GuzzleException
+     * @throws TransporterRequestException
      */
     private function initializeSession(): void
     {
@@ -38,12 +38,21 @@ class HttpTransporter implements Transporter
         }
 
         $payload = $this->preparePayload('initialize');
-        $response = $this->client->request('POST', '', [
-            'json' => $payload,
-            'timeout' => $this->config['timeout'] ?? 30,
-            'stream' => true,
-            'headers' => $this->buildRequestHeaders(),
-        ]);
+
+        try {
+            $response = $this->client->request('POST', '', [
+                'json' => $payload,
+                'timeout' => $this->config['timeout'] ?? 30,
+                'stream' => true,
+                'headers' => $this->buildRequestHeaders(),
+            ]);
+        } catch (GuzzleException $e) {
+            throw new TransporterRequestException(
+                "HTTP error during initialize handshake: {$e->getMessage()}",
+                (int) $e->getCode(),
+                $e
+            );
+        }
 
         $hdr = $response->getHeader('mcp-session-id');
         if (! empty($hdr)) {
@@ -108,7 +117,13 @@ class HttpTransporter implements Transporter
             );
         }
 
-        return $data['result'] ?? $data;
+        // JSON-RPC `result` may be any JSON value (null, scalar, array, object). When it isn't an
+        // array we hand back the full envelope so the typed `: array` return contract holds.
+        if (\array_key_exists('result', $data) && \is_array($data['result'])) {
+            return $data['result'];
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -58,7 +58,7 @@ class HttpTransporter implements Transporter
      * @throws GuzzleException
      * @throws JsonException
      */
-    public function request(string $action, ?array $params = null, ?callable $onEvent = null): array
+    public function request(string $action, array $params = [], ?callable $onEvent = null): array
     {
         $this->initializeSession();
         $payload = $this->preparePayload($action, $params);
@@ -135,12 +135,13 @@ class HttpTransporter implements Transporter
         return $idType === 'integer' || $idType === 'int' ? $id : (string) $id;
     }
 
-    private function preparePayload(string $action, ?array $params = null): array
+    private function preparePayload(string $action, array $params = []): array
     {
         return [
             'jsonrpc' => '2.0',
             'method' => $action,
-            'params' => $params ?? (object) [],
+            // Empty params must JSON-encode as {} (object), not [] (array), so spec-strict servers accept them.
+            'params' => $params === [] ? (object) [] : $params,
             'id' => $this->generateId(),
         ];
     }

--- a/src/Core/Transporters/StdioTransporter.php
+++ b/src/Core/Transporters/StdioTransporter.php
@@ -77,7 +77,7 @@ class StdioTransporter implements Transporter
         $this->sendInitializeRequests();
     }
 
-    public function request(string $action, array $params = []): array
+    public function request(string $action, array $params = [], ?callable $onEvent = null): array
     {
         $this->start();
 

--- a/src/Core/Transporters/Transporter.php
+++ b/src/Core/Transporters/Transporter.php
@@ -18,8 +18,9 @@ interface Transporter
      *
      * @param  string  $action  The JSON-RPC method (e.g., 'read_pr').
      * @param  array  $params  Parameters for the request.
-     * @param  callable(array $event):void|null  $onEvent  Optional callback invoked for each
-     *                                                     intermediate streamed event (where supported by the transport).
+     * @param  callable(array $event):void|null  $onEvent  Optional callback invoked for every
+     *                                                     decoded JSON-RPC message in a streamed response, including the final
+     *                                                     result-bearing one. Not invoked when the transport does not stream.
      * @return array Decoded JSON-RPC response.
      *
      * @throws \Exception On transport failure.

--- a/src/Core/Transporters/Transporter.php
+++ b/src/Core/Transporters/Transporter.php
@@ -18,9 +18,11 @@ interface Transporter
      *
      * @param  string  $action  The JSON-RPC method (e.g., 'read_pr').
      * @param  array  $params  Parameters for the request.
+     * @param  callable(array $event):void|null  $onEvent  Optional callback invoked for each
+     *                                                     intermediate streamed event (where supported by the transport).
      * @return array Decoded JSON-RPC response.
      *
      * @throws \Exception On transport failure.
      */
-    public function request(string $action, array $params = []): array;
+    public function request(string $action, array $params = [], ?callable $onEvent = null): array;
 }

--- a/src/MCPClient.php
+++ b/src/MCPClient.php
@@ -50,23 +50,23 @@ class MCPClient implements IMCPClient
         return new Collection($tools);
     }
 
-    public function callTool(string $toolName, mixed $params = []): mixed
+    public function callTool(string $toolName, mixed $params = [], ?callable $onEvent = null): mixed
     {
         $requestParams = [
             'name' => $toolName,
             'arguments' => (object) $params,
         ];
 
-        return $this->transporter->request('tools/call', $requestParams);
+        return $this->transporter->request('tools/call', $requestParams, $onEvent);
     }
 
-    public function readResource(string $uri): mixed
+    public function readResource(string $uri, ?callable $onEvent = null): mixed
     {
         $requestParams = [
             'uri' => $uri,
         ];
 
-        return $this->transporter->request('resources/read', $requestParams);
+        return $this->transporter->request('resources/read', $requestParams, $onEvent);
     }
 
     /**

--- a/tests/Helpers/CollectionTest.php
+++ b/tests/Helpers/CollectionTest.php
@@ -23,7 +23,7 @@ test('count on empty collection returns zero', function () {
 test('getIterator returns ArrayIterator and iterates correctly', function () use ($sampleItems) {
     $collection = new Collection($sampleItems);
     $iterator = $collection->getIterator();
-    expect($iterator)->toBeInstanceOf(\ArrayIterator::class);
+    expect($iterator)->toBeInstanceOf(ArrayIterator::class);
 
     $results = [];
     foreach ($collection as $item) {

--- a/tests/Http/SseStreamParserTest.php
+++ b/tests/Http/SseStreamParserTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Utils;
+use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
+use Redberry\MCPClient\Core\Http\SseStreamParser;
+
+describe('SseStreamParser', function () {
+    test('returns the result of a single event', function () {
+        $sse = "event: jsonrpc.message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"foo\":\"bar\"}}\n\n";
+
+        $result = SseStreamParser::parse(Utils::streamFor($sse));
+
+        expect($result)->toEqual(['foo' => 'bar']);
+    });
+
+    test('returns the last result-bearing event when several are sent', function () {
+        $sse = <<<'SSE'
+event: jsonrpc.message
+data: {"jsonrpc":"2.0","id":1,"result":{"step":"first"}}
+
+event: jsonrpc.message
+data: {"jsonrpc":"2.0","id":1,"result":{"step":"second"}}
+
+data: [DONE]
+
+SSE;
+
+        $result = SseStreamParser::parse(Utils::streamFor($sse));
+
+        expect($result)->toEqual(['step' => 'second']);
+    });
+
+    test('invokes $onEvent for every decoded event', function () {
+        $sse = <<<'SSE'
+data: {"jsonrpc":"2.0","method":"progress","params":{"pct":25}}
+
+data: {"jsonrpc":"2.0","method":"progress","params":{"pct":75}}
+
+data: {"jsonrpc":"2.0","id":1,"result":{"done":true}}
+
+SSE;
+
+        $seen = [];
+        $result = SseStreamParser::parse(
+            Utils::streamFor($sse),
+            function (array $event) use (&$seen) {
+                $seen[] = $event;
+            }
+        );
+
+        expect($result)->toEqual(['done' => true])
+            ->and($seen)->toHaveCount(3)
+            ->and($seen[0]['params']['pct'])->toBe(25)
+            ->and($seen[1]['params']['pct'])->toBe(75)
+            ->and($seen[2]['result']['done'])->toBeTrue();
+    });
+
+    test('joins multi-line `data:` fields with newlines', function () {
+        $sse = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\ndata: \"result\":{\"text\":\"hi\"}}\n\n";
+
+        $result = SseStreamParser::parse(Utils::streamFor($sse));
+
+        expect($result)->toEqual(['text' => 'hi']);
+    });
+
+    test('skips comment lines starting with colon', function () {
+        $sse = <<<'SSE'
+: this is a heartbeat
+
+: another comment
+data: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}
+
+SSE;
+
+        $result = SseStreamParser::parse(Utils::streamFor($sse));
+
+        expect($result)->toEqual(['ok' => true]);
+    });
+
+    test('treats [DONE] sentinel events as terminators (no result)', function () {
+        $sse = <<<'SSE'
+data: {"jsonrpc":"2.0","id":1,"result":{"value":42}}
+
+data: [DONE]
+
+SSE;
+
+        $result = SseStreamParser::parse(Utils::streamFor($sse));
+
+        expect($result)->toEqual(['value' => 42]);
+    });
+
+    test('flushes a trailing event that lacks a terminating blank line', function () {
+        $sse = 'data: {"jsonrpc":"2.0","id":1,"result":{"trailing":true}}';
+
+        $result = SseStreamParser::parse(Utils::streamFor($sse));
+
+        expect($result)->toEqual(['trailing' => true]);
+    });
+
+    test('throws when an event carries a JSON-RPC error', function () {
+        $sse = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}\n\n";
+
+        expect(fn () => SseStreamParser::parse(Utils::streamFor($sse)))
+            ->toThrow(TransporterRequestException::class, 'JSON-RPC error: Method not found');
+    });
+
+    test('throws when the stream ends without any result', function () {
+        $sse = <<<'SSE'
+data: {"jsonrpc":"2.0","method":"progress","params":{"pct":50}}
+
+data: [DONE]
+
+SSE;
+
+        expect(fn () => SseStreamParser::parse(Utils::streamFor($sse)))
+            ->toThrow(TransporterRequestException::class, 'SSE stream ended without a JSON-RPC result.');
+    });
+
+    test('throws JsonException on malformed event payload', function () {
+        $sse = "data: not-valid-json\n\n";
+
+        expect(fn () => SseStreamParser::parse(Utils::streamFor($sse)))
+            ->toThrow(JsonException::class);
+    });
+
+    test('handles an empty stream by throwing', function () {
+        expect(fn () => SseStreamParser::parse(Utils::streamFor('')))
+            ->toThrow(TransporterRequestException::class, 'SSE stream ended without a JSON-RPC result.');
+    });
+});

--- a/tests/MCPClient/MCPClientTest.php
+++ b/tests/MCPClient/MCPClientTest.php
@@ -104,6 +104,44 @@ describe('MCPClient', function () {
             ->toHaveCount(2);
     });
 
+    test('callTool forwards onEvent callback to the transporter', function () {
+        $callback = fn (array $event) => null;
+
+        $mockTransporter = Mockery::mock(Transporter::class);
+        $mockFactory = Mockery::mock(TransporterFactory::class);
+
+        $mockTransporter->shouldReceive('request')
+            ->once()
+            ->with('tools/call', Mockery::type('array'), $callback)
+            ->andReturn(['ok' => true]);
+
+        $mockFactory->shouldReceive('make')->andReturn($mockTransporter);
+
+        $client = new MCPClient(config('mcp-client.servers'), $mockFactory);
+        $client->connect('using_enum');
+
+        expect($client->callTool('do', ['x' => 1], $callback))->toEqual(['ok' => true]);
+    });
+
+    test('readResource forwards onEvent callback to the transporter', function () {
+        $callback = fn (array $event) => null;
+
+        $mockTransporter = Mockery::mock(Transporter::class);
+        $mockFactory = Mockery::mock(TransporterFactory::class);
+
+        $mockTransporter->shouldReceive('request')
+            ->once()
+            ->with('resources/read', ['uri' => 'file:///x'], $callback)
+            ->andReturn(['content' => 'hi']);
+
+        $mockFactory->shouldReceive('make')->andReturn($mockTransporter);
+
+        $client = new MCPClient(config('mcp-client.servers'), $mockFactory);
+        $client->connect('using_enum');
+
+        expect($client->readResource('file:///x', $callback))->toEqual(['content' => 'hi']);
+    });
+
     test('tools throws exception when not connected', function () {
         $client = new MCPClient(config('mcp-client.servers'));
 

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -344,7 +344,7 @@ SSE;
         expect($transporter->request('stream'))->toEqual(['ok' => true]);
     });
 
-    test('onEvent callback receives every intermediate SSE event', function () {
+    test('onEvent callback receives every SSE event including the final result', function () {
         [$transporter, $mockClient] = createTransporterWithMockedSession();
 
         $sse = <<<'SSE'
@@ -366,6 +366,33 @@ SSE;
             ->and($events)->toHaveCount(2)
             ->and($events[0]['method'])->toBe('progress')
             ->and($events[1]['result']['done'])->toBeTrue();
+    });
+
+    test('connection failure during initialize is wrapped as TransporterRequestException', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->andThrow(new TransferException('init refused', 503));
+
+        $this->expectException(TransporterRequestException::class);
+        $this->expectExceptionMessage('HTTP error during initialize handshake: init refused');
+        $this->expectExceptionCode(503);
+
+        $transporter->request('anything');
+    });
+
+    test('JSON response with scalar result returns the full envelope', function () {
+        [$transporter, $mockClient] = createTransporterWithMockedSession();
+
+        $response = new Response(200, ['Content-Type' => 'application/json'], json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => 'plain-string']));
+        $mockClient->shouldReceive('request')->once()->andReturn($response);
+
+        $result = $transporter->request('act');
+
+        expect($result)->toBeArray()
+            ->and($result['result'])->toBe('plain-string');
     });
 
     test('initialize handshake captures mcp-session-id and reuses it', function () {

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
 use Redberry\MCPClient\Core\Transporters\HttpTransporter;
 
@@ -282,5 +283,109 @@ describe('HttpTransporter', function () {
         $this->expectExceptionCode(502);
 
         $transporter->request('networkFailure', []);
+    });
+
+    test('client can be injected via constructor (no reflection needed)', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $initResp = new Response(200, ['mcp-session-id' => 'sid-99', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $reqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => ['ok' => 1]]));
+
+        $mockClient->shouldReceive('request')->once()->with('POST', '', Mockery::type('array'))->andReturn($initResp);
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['headers']['mcp-session-id'] ?? null) === 'sid-99'))
+            ->andReturn($reqResp);
+
+        expect($transporter->request('ping'))->toEqual(['ok' => 1]);
+    });
+
+    test('every request advertises both content types in Accept', function () {
+        [$transporter, $mockClient] = createTransporterWithMockedSession();
+
+        $response = new Response(200, [], json_encode(['result' => ['ok' => true]]));
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['headers']['Accept'] ?? '') === 'application/json, text/event-stream'
+                && ($opts['stream'] ?? null) === true))
+            ->andReturn($response);
+
+        $transporter->request('act');
+    });
+
+    test('SSE response is parsed and final result returned', function () {
+        [$transporter, $mockClient] = createTransporterWithMockedSession();
+
+        $sse = <<<'SSE'
+event: jsonrpc.message
+data: {"jsonrpc":"2.0","id":1,"result":{"value":"final"}}
+
+data: [DONE]
+
+SSE;
+
+        $response = new Response(200, ['Content-Type' => 'text/event-stream'], Utils::streamFor($sse));
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::type('array'))
+            ->andReturn($response);
+
+        expect($transporter->request('stream'))->toEqual(['value' => 'final']);
+    });
+
+    test('SSE Content-Type with charset suffix is recognized', function () {
+        [$transporter, $mockClient] = createTransporterWithMockedSession();
+
+        $sse = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n";
+        $response = new Response(200, ['Content-Type' => 'text/event-stream; charset=utf-8'], Utils::streamFor($sse));
+        $mockClient->shouldReceive('request')->once()->andReturn($response);
+
+        expect($transporter->request('stream'))->toEqual(['ok' => true]);
+    });
+
+    test('onEvent callback receives every intermediate SSE event', function () {
+        [$transporter, $mockClient] = createTransporterWithMockedSession();
+
+        $sse = <<<'SSE'
+data: {"jsonrpc":"2.0","method":"progress","params":{"pct":50}}
+
+data: {"jsonrpc":"2.0","id":1,"result":{"done":true}}
+
+SSE;
+
+        $response = new Response(200, ['Content-Type' => 'text/event-stream'], Utils::streamFor($sse));
+        $mockClient->shouldReceive('request')->once()->andReturn($response);
+
+        $events = [];
+        $result = $transporter->request('stream', null, function (array $evt) use (&$events) {
+            $events[] = $evt;
+        });
+
+        expect($result)->toEqual(['done' => true])
+            ->and($events)->toHaveCount(2)
+            ->and($events[0]['method'])->toBe('progress')
+            ->and($events[1]['result']['done'])->toBeTrue();
+    });
+
+    test('initialize handshake captures mcp-session-id and reuses it', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $initResp = new Response(200, ['mcp-session-id' => 'session-xyz', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $reqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => ['after' => true]]));
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ! isset($opts['headers']['mcp-session-id'])
+                && ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp);
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['headers']['mcp-session-id'] ?? null) === 'session-xyz'))
+            ->andReturn($reqResp);
+
+        expect($transporter->request('after_init'))->toEqual(['after' => true]);
     });
 });

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -358,7 +358,7 @@ SSE;
         $mockClient->shouldReceive('request')->once()->andReturn($response);
 
         $events = [];
-        $result = $transporter->request('stream', null, function (array $evt) use (&$events) {
+        $result = $transporter->request('stream', [], function (array $evt) use (&$events) {
             $events[] = $evt;
         });
 

--- a/tests/Transporter/StdioTransporterTest.php
+++ b/tests/Transporter/StdioTransporterTest.php
@@ -140,7 +140,7 @@ describe('StdioTransporter', function () {
         $transporter->shouldNotReceive('sendInitializeRequests'); // should not reach this
 
         $process = Mockery::mock(Process::class);
-        $process->shouldReceive('start')->once()->andThrow(new \RuntimeException('start failure'));
+        $process->shouldReceive('start')->once()->andThrow(new RuntimeException('start failure'));
         $process->shouldReceive('isRunning')->andReturn(false)->byDefault();
 
         $ref = new ReflectionClass(StdioTransporter::class);


### PR DESCRIPTION
This adds support for the Streamable HTTP transport from the MCP 2025-03-26 spec by extending the existing `HttpTransporter`. Came out of the discussion around #29 — different shape from what was proposed there.

The spec puts the streaming decision on the server side: the client always sends `Accept: application/json, text/event-stream` and the server picks per call between a JSON response and an SSE stream of JSON-RPC messages. So there's no client-side knob for "should this request stream," and that's why I didn't add a separate `StreamableHttpTransporter` class — one transport, content-negotiated on the response.

### Changes

- New `Core/Http/SseStreamParser` handles SSE decoding (multi-line `data:`, comment lines, `[DONE]` sentinel, trailing-line flush, errors). Standalone so it's testable without HTTP mocks.
- `HttpTransporter::request()` branches on response `Content-Type` and passes Guzzle `stream => true` so SSE bodies aren't buffered. Constructor now takes an optional `ClientInterface` for cleaner test injection.
- Optional `?callable \$onEvent` on the `Transporter` interface, threaded through `MCPClient::callTool()` / `readResource()`. Lets callers observe streamed events when the server picks SSE; fires zero times when it picks JSON, so it's safe to pass unconditionally. `StdioTransporter` accepts and ignores it for now.
- `composer.json` now actually declares `guzzlehttp/guzzle` and `psr/http-message` — the HTTP transporter has always relied on these transitively.

### Not in this PR

- The optional `GET /` SSE channel for unsolicited server→client notifications.
- `Last-Event-ID` resumability.
- Pre-existing spec-compliance gaps in the `initialize` payload (missing `protocolVersion`/`capabilities`/`clientInfo`) and the follow-up `notifications/initialized` notification. Worth a separate PR.

### Tests

19 new tests — 11 for the parser, 6 for the transporter, 2 for `MCPClient`. 83 total pass, phpstan clean, pint clean.

The second commit (\`chore: fix pre-existing Pint style issues\`) fixes three unrelated files flagged by \`pint --test\` on this branch. Main hasn't had a PHP push in a while, so CI hadn't surfaced them yet.