### PR TITLE
docs: add AI/contributor context (CLAUDE.md, ARCHITECTURE.md, etc.)

### DIFF
--- a/.claude/rules/mcp-spec.md
+++ b/.claude/rules/mcp-spec.md
@@ -1,0 +1,107 @@
+# MCP Spec Rules
+
+This package targets the Model Context Protocol spec. Treat the spec as authoritative; this file pins which version we're on, the message shapes we use, and what is intentionally **not** in scope.
+
+## Pinned spec version
+
+- **HTTP transport:** [`2025-03-26` Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). This is the only HTTP shape we implement.
+- **STDIO transport:** Currently uses `protocolVersion: '2024-11-05'` in `StdioTransporter::PROTOCOL_VERSION`. ROADMAP P0 promotes `PROTOCOL_VERSION` to a single shared location and aligns both transporters to `2025-03-26`. Do not introduce a third version.
+
+When you reach for the spec, link the section anchor in your PR description so reviewers can verify against the same revision you used.
+
+## JSON-RPC envelope
+
+All messages are JSON-RPC 2.0:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": { ... } }
+```
+
+Rules:
+
+- `jsonrpc` is always the literal string `"2.0"`.
+- `id` is required for requests, **omitted** for notifications. See `StdioTransporter::sendInitializeRequests()` for an example: `initialize` has an `id`, the follow-up `notifications/initialized` does not.
+- Empty `params` must serialize as `{}` (object), not `[]` (array). `HttpTransporter::preparePayload()` handles this with `params === [] ? (object) [] : $params`.
+- Errors come back as `{"error": {"code": int, "message": string, "data"?: any}}`. `message` is **optional in practice** even though the spec says SHOULD — defensive code reads it as `$decoded['error']['message'] ?? 'Unknown JSON-RPC error'` (see ROADMAP P1 for the SSE parser's gap).
+
+## Initialize handshake
+
+Required for **both** transports before any user-issued request. Two messages, in order:
+
+```json
+// 1. Request
+{
+  "jsonrpc": "2.0",
+  "id": "init",
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {},
+    "clientInfo": { "name": "mcp-client-laravel", "version": "<from composer>" }
+  }
+}
+
+// 2. Notification (no id field)
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized",
+  "params": {}
+}
+```
+
+- Strict-spec servers (Anthropic's reference servers, the official TS reference) reject an `initialize` payload missing any of `protocolVersion`, `capabilities`, `clientInfo`.
+- The HTTP transport additionally captures `mcp-session-id` from the `initialize` response headers and replays it on every subsequent request as a header.
+- `clientInfo.version` must come from `\Composer\InstalledVersions::getPrettyVersion('redberry/mcp-client-laravel')`, not a hardcoded string.
+
+## Streamable HTTP specifics
+
+- Every request must advertise `Accept: application/json, text/event-stream`. The server picks per call.
+- Response Content-Type drives parsing:
+  - `application/json` → single JSON-RPC message; decode and return `result`.
+  - `text/event-stream` → hand the body to `SseStreamParser::parse()` and let it drive `$onEvent` until the result-bearing event arrives.
+- Session loss surfaces as either HTTP 404 or a JSON-RPC error indicating "session not found". The client should clear session state, re-initialize, and retry once (ROADMAP P3 tracks the implementation).
+
+## SSE event format
+
+Server-Sent Events as MCP uses them:
+
+```
+event: message
+data: {"jsonrpc":"2.0","id":1,"result":{...}}
+
+```
+
+- Events are separated by a blank line (`\n\n`).
+- Multi-line `data:` values are concatenated with `\n` before JSON-decoding.
+- Lines starting with `:` are comments — ignore them.
+- A bare `[DONE]` sentinel ends the stream without a result; treat as no-op (we don't synthesize a result from it).
+- Every decoded JSON-RPC message — notifications, progress (`notifications/progress`), log entries, and the final result — is surfaced via `$onEvent`. Only the final result-bearing message becomes the return value.
+
+## Error code conventions
+
+Pass JSON-RPC error codes through to the `TransporterRequestException` code unchanged. Common ones to handle without inventing new layers:
+
+- `-32700` Parse error
+- `-32600` Invalid request
+- `-32601` Method not found
+- `-32602` Invalid params
+- `-32603` Internal error
+- Server-defined codes in the `-32000` to `-32099` range — treat opaquely.
+
+## Out of scope
+
+Don't start work on these without explicit confirmation. They're documented as out-of-scope in [ROADMAP.md:98–102](../../ROADMAP.md):
+
+- **Long-lived `GET /` SSE channel** for unsolicited server→client notifications. We are request/response only.
+- **`Last-Event-ID` resumability** on Streamable HTTP. We don't checkpoint or resume.
+- **Sampling / completions / elicitation flows** beyond `tools/list`, `tools/call`, `resources/list`, `resources/read`. The current `MCPClient` API is intentionally narrow.
+- **Server capabilities advertising** beyond what `initialize` returns — we don't currently inspect or branch on the server's capabilities object.
+
+If a feature in this list becomes necessary, raise it as a new ROADMAP item before writing code.
+
+## Reference links
+
+- Spec index: <https://modelcontextprotocol.io/specification/2025-03-26>
+- JSON-RPC 2.0: <https://www.jsonrpc.org/specification>
+- Streamable HTTP transport: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http>
+- Lifecycle / `initialize`: <https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle>

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,36 @@
+# Testing Rules
+
+- Framework: **Pest** (not raw PHPUnit), bootstrapped via `tests/Pest.php` which applies `Redberry\MCPClient\Tests\TestCase` to everything under `tests/`.
+- Base class: `tests/TestCase.php` extends Orchestra Testbench and registers `MCPClientServiceProvider`. Don't introduce a second base class — extend or compose if you need more setup.
+- File naming: `{ClassName}Test.php` placed under the directory matching its concern (`Transporter/`, `Http/`, `MCPClient/`, `Helpers/`).
+- Use `it('does X', function () { ... })` and `describe()` blocks. Don't use PHPUnit-style `public function test_X()` methods in new files.
+- Run a single test: `vendor/bin/pest --filter="test name"`. Run a directory: `vendor/bin/pest tests/Transporter/`.
+
+## No real network or subprocesses
+
+- HTTP transporter tests must mock Guzzle. The constructor accepts `?GuzzleHttp\ClientInterface`, so build a `Client` with a `GuzzleHttp\Handler\MockHandler` stack and inject it. There is an existing helper in `tests/Transporter/HttpTransporterTest.php` showing constructor injection — copy that pattern.
+- Don't use `ReflectionClass` to set private state on a transporter in new tests. The legacy `createTransporterWithMockedSession()` helper is on the way out (ROADMAP P4) — adding more callers makes that cleanup harder.
+- STDIO transporter tests must not spawn real `npx` or other commands. Use a script fixture or a stub command that emits known JSON-RPC lines.
+- SSE parser tests should feed a Guzzle/PSR `StreamInterface` mock — see `tests/Http/SseStreamParserTest.php` for the pattern.
+
+## Fixtures
+
+- Real-shape responses live in `tests/Datasets/` (e.g. `GithubResponseExample.php`). Add new fixture data there as `return`-style PHP files, not inline string heredocs.
+- When a fixture corresponds to a specific MCP server's response, name the file after the server (`GithubResponseExample.php`, not `Example1.php`).
+
+## What to test for a new transporter
+
+- Happy path: a successful `request()` returns the decoded JSON-RPC `result` array.
+- Error path: a JSON-RPC error response throws `TransporterRequestException` carrying the spec error code.
+- Initialization: the `initialize` exchange happens exactly once per instance and uses the spec-correct payload (`protocolVersion`, `capabilities`, `clientInfo`) — see `mcp-spec.md`.
+- `$onEvent`: invoked for every decoded event when the transport streams; not invoked when the transport returns a single message. Document explicitly which case applies.
+
+## What to test for changes to `MCPClient` or the facade
+
+- `connect()` raises a `RuntimeException` for unknown server names (see `MCPClient::ensureConfigurationValidity()`).
+- `tools()` and `resources()` strip the `tools`/`resources` envelope and return a `Collection`.
+- `callTool()` forwards `$onEvent` to the transporter; `tools()`/`resources()` do not (they call `request()` directly).
+
+## Architecture rule
+
+`tests/ArchTest.php` forbids `dd`, `dump`, `ray`. Don't disable or relax that rule. If you need to debug, use a local `error_log()` or `\Illuminate\Support\Facades\Log` call and remove it before committing.

--- a/.claude/rules/transporters.md
+++ b/.claude/rules/transporters.md
@@ -1,0 +1,46 @@
+# Transporter Rules
+
+When adding a new transport (e.g. WebSocket) or modifying `HttpTransporter` / `StdioTransporter`, follow these rules.
+
+## Contract
+
+1. Every transport implements `Redberry\MCPClient\Core\Transporters\Transporter` and only that interface — one method, `request(string $action, array $params = [], ?callable $onEvent = null): array`.
+2. The return value is the JSON-RPC `result`, decoded as an associative array. If the spec `result` isn't an array (rare — null/scalar), return the full envelope so the `: array` return contract holds. `HttpTransporter::parseResponse()` already does this; mirror it.
+3. Throw `Redberry\MCPClient\Core\Exceptions\TransporterRequestException` for any transport-layer failure: network error, JSON-RPC error response, malformed payload, timeout, session loss. Carry the spec error code through as the exception code where possible.
+4. Throw `Redberry\MCPClient\Core\Exceptions\ServerConfigurationException` from the constructor for invalid config shapes (e.g. missing required key, wrong type).
+5. The constructor takes `array $config` as its first parameter. Any external dependency (HTTP client, process factory) should be the second parameter, optional, with a sensible default — this is the seam tests use to inject mocks.
+
+## Initialization
+
+6. Run the MCP `initialize` handshake exactly once per instance, lazily on the first user request. Don't run it in the constructor.
+7. The initialize payload must include `protocolVersion`, `capabilities` (empty object `(object)[]` is fine), and `clientInfo` (`name`, `version`). After a successful `initialize`, send a `notifications/initialized` notification (no `id` field — it's not a request). See `mcp-spec.md` for the exact shape.
+8. Reference a single shared `PROTOCOL_VERSION` constant — once it's promoted to the `Transporter` interface or a `Core/Mcp.php` value object (per ROADMAP P0), use it. Don't redeclare a per-class constant.
+9. `clientInfo.version` must be sourced from the package's installed version, not hardcoded. Use `\Composer\InstalledVersions::getPrettyVersion('redberry/mcp-client-laravel')` with a string fallback.
+
+## Request IDs
+
+10. Use a per-instance incrementing counter for JSON-RPC `id` (see `StdioTransporter::$requestId`). Don't use `random_int` — birthday collisions become non-trivial over a long-lived session. The `id_type` config flag (`'int'` vs `'string'`) only controls how the counter is cast.
+
+## State and reuse
+
+11. A transporter instance may hold session state (HTTP session id, STDIO process handle) for the duration of its life. Don't share state across instances via static properties.
+12. On detected session loss (HTTP 404 with the spec session-not-found code, or a JSON-RPC error indicating the same), clear the session, re-initialize once, and retry the original request once. Surface as `TransporterRequestException` if the retry also fails. (See ROADMAP P3 — the HTTP transporter doesn't do this yet; new transports should plan for it.)
+
+## The `$onEvent` callback
+
+13. If the transport streams (server can emit multiple JSON-RPC messages between request and final result), invoke `$onEvent` for **every** decoded message — notifications, progress, and the final result-bearing one — in arrival order.
+14. If the transport doesn't stream (single request/response), `$onEvent` is a no-op. Document this explicitly in the class-level docblock so callers know the callback is conditional on the active transport.
+15. `$onEvent` must be safe to call when null. Don't call without a null guard.
+
+## Registration
+
+16. Add the new transport to the `Redberry\MCPClient\Enums\Transporters` enum and to `TransporterFactory::make()`'s `match` arm. The factory is the only place that maps config `type` → concrete class — don't add resolution logic anywhere else.
+17. If the new transport requires new config keys, document them in `config/mcp-client.php` with inline comments describing default and unit (ms / seconds).
+
+## Don't
+
+- Don't read `config()` from inside a transporter — accept everything via `array $config` in the constructor.
+- Don't throw raw `\Exception` or `\RuntimeException` from request paths — wrap in `TransporterRequestException` so callers have one exception type to catch.
+- Don't introduce a second IO seam (e.g. raw `fopen` / `curl_exec`). Reuse Guzzle for HTTP-shaped transports and Symfony Process for subprocess-shaped ones.
+- Don't add cross-request global state (static properties, singletons).
+- Don't break the existing `Transporter` interface signature without a coordinated change to all implementations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+See [CLAUDE.md](CLAUDE.md) for the full set of agent-facing guidance — project overview, commands, file map, architecture, conventions, and definition of done. Domain-specific rules live in [`.claude/rules/`](.claude/rules/).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,337 @@
+# Architecture
+
+This document describes how `redberry/mcp-client-laravel` is put together internally — the layers, the request flow, transport lifecycles, and the rationale for non-obvious choices. It complements `CLAUDE.md` (which is a quick reference) and the per-domain rule files in `.claude/rules/`.
+
+If you only need to *use* the package, the [README](README.md) has everything. This document is for people changing the package itself.
+
+---
+
+## Layers
+
+The package is four small layers stacked on top of each other:
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ Public API           MCPClient (facade + concrete) ──────────────► │  user-facing
+│                      Collection                                    │
+├────────────────────────────────────────────────────────────────────┤
+│ Service binding      MCPClientServiceProvider                      │  Laravel glue
+│                      TransporterFactory                            │
+├────────────────────────────────────────────────────────────────────┤
+│ Transport            Transporter (interface)                       │  IO seam
+│                      ├── HttpTransporter                           │
+│                      └── StdioTransporter                          │
+├────────────────────────────────────────────────────────────────────┤
+│ Wire decoding        SseStreamParser                               │  parsers
+│                      JSON-RPC envelope handling (in transporters)  │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Each layer talks only to the one immediately below it. The **transport layer is the only IO seam** — every byte that crosses the network or stdin/stdout boundary goes through `Transporter::request()`. That's deliberate: it's the only thing tests need to mock, and the only place a new transport can be added.
+
+---
+
+## Public API surface
+
+The user-facing API lives in `src/MCPClient.php` and is intentionally small:
+
+| Method | Purpose | Streams? |
+|---|---|---|
+| `connect(string $serverName)` | Picks a server config out of the map and instantiates the transporter via `TransporterFactory` | — |
+| `tools(): Collection` | `tools/list` JSON-RPC call | No |
+| `resources(): Collection` | `resources/list` JSON-RPC call | No |
+| `callTool(string $name, mixed $params, ?callable $onEvent): mixed` | `tools/call` JSON-RPC call, forwards `$onEvent` | Yes (when transport supports it) |
+| `readResource(string $uri, ?callable $onEvent): mixed` | `resources/read` JSON-RPC call, forwards `$onEvent` | Yes (when transport supports it) |
+
+The contract for both `MCPClient` and the underlying `Transporter` lives in `src/Contracts/MCPClient.php` and `src/Core/Transporters/Transporter.php` — keep both interfaces narrow.
+
+`Collection` (`src/Collection.php`) is a tiny `Countable + IteratorAggregate` wrapper with `all()`, `only(...$names)`, `except(...$names)`, `map($fn)`, and `toArray()`. It is **not** Laravel's `Illuminate\Support\Collection` — keeping it standalone avoids pulling the full collections package as a hard dep and avoids name collisions in user code.
+
+---
+
+## Service binding
+
+`MCPClientServiceProvider` (`src/MCPClientServiceProvider.php`) uses `spatie/laravel-package-tools` to:
+
+1. Register the published config file (`config/mcp-client.php`).
+2. Register the `MCPClientCommand` artisan command.
+3. In `packageBooted()`, bind `Redberry\MCPClient\MCPClient` to a closure that pulls the `mcp-client.servers` array from config and constructs a fresh client.
+
+**This is the only place in the package that reads `config()` or wires concrete classes.** Every other class takes its configuration through the constructor. Two consequences:
+
+- Tests can construct `MCPClient` directly with a literal `$servers` array — no Laravel container needed beyond what Orchestra Testbench provides.
+- A user who wants a non-default config (e.g. a per-tenant server map) can resolve the binding manually, `MCPClient` stays oblivious.
+
+The factory itself (`TransporterFactory::make()`) is the only place that maps the `Transporters` enum value to a concrete transporter class. Adding a new transport is a two-line change there plus a new enum case.
+
+---
+
+## Request flow
+
+The full happy-path flow for a streamed `callTool()`:
+
+```
+Caller code
+    │
+    ▼
+MCPClient::callTool($name, $args, $onEvent)
+    │   builds {name, arguments} params
+    ▼
+Transporter::request('tools/call', $params, $onEvent)        ◄── interface call
+    │
+    ├─ (HTTP)                                  │ ├─ (STDIO)
+    │  initializeSession()  if not yet done    │ │  start() if process not running
+    │  preparePayload(method, params, id)      │ │  preparePayload(method, params, id)
+    │  POST with Accept: json, event-stream    │ │  fwrite(stdin, json + "\n")
+    │  parseResponse():                        │ │  waitForResponse($id):
+    │    ├─ Content-Type: text/event-stream    │ │    poll getIncrementalOutput()
+    │    │  → SseStreamParser::parse(body, $onEvent)         every poll_interval ms
+    │    └─ Content-Type: application/json     │ │    until a line with matching id
+    │       → json_decode + return result      │ │  return $data['result']
+    ▼                                          ▼ ▼
+Caller receives the JSON-RPC `result` (decoded array)
+```
+
+Two paths meet at the same return shape: the JSON-RPC `result` field, decoded as an associative array. If a server returns a non-array `result` (rare — null, scalar), the HTTP transporter hands back the full envelope so the `: array` return contract holds. STDIO does not currently handle this edge case.
+
+---
+
+## HTTP transport
+
+`Redberry\MCPClient\Core\Transporters\HttpTransporter` implements MCP's [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) (`2025-03-26`).
+
+### Lifecycle
+
+```
+new HttpTransporter($config, ?$guzzleClient)
+    │
+    ▼
+first request()
+    │
+    ├─ initializeSession()   ◄── runs once per instance
+    │   POST '' with initialize payload
+    │   capture mcp-session-id from response header
+    │   set $initialized = true
+    │
+    └─ user request
+        POST '' with method+params
+        replay mcp-session-id header on every call
+        parseResponse() branches on Content-Type
+```
+
+- **Why lazy initialize.** Constructing a transporter shouldn't make a network call. Deferring the handshake until the first real request keeps the constructor cheap and lets tests build instances without any IO.
+- **Why one Guzzle client per instance.** Guzzle clients hold connection pools and base config. Reusing a single client across all requests in a session means HTTP keep-alive works for free.
+- **Why `stream => true` on every request.** It lets us hand the body to `SseStreamParser` without buffering the full response. For non-stream responses it's a small no-op cost.
+- **Why constructor-injected client.** Tests inject a `Client` wrapping `GuzzleHttp\Handler\MockHandler`. No reflection needed for new tests.
+
+### Response parsing
+
+`parseResponse()` reads the first segment of `Content-Type`, lowercased and trimmed:
+
+- `text/event-stream` → `SseStreamParser::parse($body, $onEvent)`. The parser drives `$onEvent` and returns the result-bearing payload.
+- anything else → `json_decode` → return `$data['result']` if it's an array, else the whole envelope.
+
+JSON-RPC errors (`isset($data['error'])`) throw `TransporterRequestException` carrying the spec error code as the exception code.
+
+### Known gaps (tracked in ROADMAP)
+
+- `initializeSession()` sends a bare `initialize` payload missing `protocolVersion` / `capabilities` / `clientInfo`, and never sends the follow-up `notifications/initialized`. Strict-spec servers reject this. (P0)
+- `random_int` request id generator can collide over a long-lived session. Should be an incrementing counter like STDIO. (P5)
+- No SSE read-timeout — a server that holds the connection open without sending parks the worker. (P2)
+- No session-loss recovery — a 404 from the server keeps replaying the stale session id. (P3)
+
+---
+
+## STDIO transport
+
+`Redberry\MCPClient\Core\Transporters\StdioTransporter` runs the configured command as a subprocess via Symfony Process and exchanges newline-delimited JSON-RPC over stdin/stdout.
+
+### Lifecycle
+
+```
+new StdioTransporter($config)
+    validateConfig()        ◄── empty command → ServerConfigurationException
+    │
+    ▼
+first request()
+    │
+    ├─ start():
+    │   initializeProcess()           ◄── builds Process with InputStream
+    │   $process->start()
+    │   usleep(startup_delay)         ◄── give server time to boot, default 50ms
+    │   isRunning()? else handleStartupFailure()
+    │   sendInitializeRequests():
+    │     write {initialize} \n
+    │     write {initialized} \n      ◄── note: spec name is notifications/initialized
+    │
+    └─ user request
+        write {method, params, id: ++$requestId} \n
+        waitForResponse($id):
+          loop:
+            buffer .= $process->getIncrementalOutput()
+            for each newline-terminated line in buffer:
+              json_decode; if id matches, return result (or throw on error)
+            usleep(poll_interval), default 10ms
+            timeout after $config['timeout']s
+            (default 3s — short on purpose)
+    ▼
+__destruct() / close()
+    inputStream->close()
+    process->stop() if still running
+```
+
+- **Why lazy start.** Same reasoning as HTTP — constructing shouldn't fork a process.
+- **Why a startup delay.** Many MCP servers (especially `npx`-launched Node ones) take a moment to be ready to read from stdin. Without the delay, the first `initialize` write can race the server's readline loop. 50ms is a deliberately small default; users override via `startup_delay` ms.
+- **Why polling instead of blocking reads.** Symfony Process's `getIncrementalOutput()` is non-blocking and drains both buffered stdout and any new bytes since the last call. We poll because the server can interleave notifications between requests, and we need to walk every line looking for our matching `id`.
+- **Why a per-instance counter for ids.** `++$this->requestId` is collision-free for the lifetime of the instance. No randomness, no `id_type` wobble — the cast to string is the only branch.
+
+### Asymmetry with HTTP
+
+- `$onEvent` is currently **a no-op on STDIO** — the contract accepts it, but `waitForResponse()` only matches against the `id` and returns the result. We don't decode and surface intermediate notifications today. ROADMAP P6 tracks documenting this clearly in the README.
+- STDIO uses `protocolVersion: '2024-11-05'` while the HTTP target is `2025-03-26`. ROADMAP P0 promotes the constant to one shared place and aligns both.
+- STDIO hardcodes `clientInfo.version` to `'0.1.0'`. Should be sourced from `\Composer\InstalledVersions` (P0).
+
+---
+
+## SSE parsing
+
+`Redberry\MCPClient\Core\Http\SseStreamParser` decodes [Server-Sent Events](https://html.spec.whatwg.org/multipage/server-sent-events.html) where each event carries one JSON-RPC message in its `data:` field.
+
+### Wire format
+
+```
+event: message
+data: {"jsonrpc":"2.0","method":"notifications/progress","params":{...}}
+
+event: message
+data: {"jsonrpc":"2.0","id":1,"result":{...}}
+
+```
+
+### Algorithm
+
+```
+parse(StreamInterface $stream, ?callable $onEvent): array
+    buffer  = ''
+    current = {event: null, data: ''}
+    final   = null
+
+    while not eof:
+        chunk = $stream->read(8192)
+        if chunk empty, continue
+        buffer .= chunk
+        drainLines(buffer, current, final, onEvent)
+
+    # flush trailing partial event without terminator
+    if buffer or current.data:
+        buffer .= "\n\n"
+        drainLines(buffer, current, final, onEvent)
+
+    if final is null:
+        throw  // stream ended without a result
+    return final
+```
+
+`drainLines()` walks complete `\n`-terminated lines from the buffer. A blank line dispatches the accumulated event:
+
+- Decode `current.data` as JSON.
+- If the JSON has `error`, throw `TransporterRequestException`.
+- If `$onEvent` is set, call it with the decoded message.
+- If the message has a `result`, record it as the new "final."
+- Reset `current` to an empty event.
+
+Comment lines (`:`-prefixed) and `data: [DONE]` sentinels are ignored. Multi-line `data:` continuations are concatenated with `\n` before decoding.
+
+### Why a custom parser
+
+Guzzle doesn't ship an SSE decoder; pulling one as a dep just for this one use case isn't worth it. The class is ~140 lines and has explicit unit tests in `tests/Http/SseStreamParserTest.php`.
+
+### Known gap
+
+Error events with no `message` field emit an undefined-index warning today (P1 in ROADMAP). Defensive read: `$decoded['error']['message'] ?? 'Unknown JSON-RPC error'`.
+
+---
+
+## Configuration
+
+`config/mcp-client.php` is a flat map of server-name → server-config. Two transport shapes:
+
+### HTTP
+
+```php
+'github' => [
+    'type'     => Transporters::HTTP,
+    'base_url' => 'https://api.githubcopilot.com/mcp',
+    'timeout'  => 30,                    // seconds; bounds connection setup, NOT body reads
+    'token'    => env('GITHUB_API_TOKEN'),
+    'id_type'  => 'int',                 // 'int' | 'string' — JSON-RPC id cast
+    'headers'  => [],                    // override Accept/Authorization if needed
+],
+```
+
+### STDIO
+
+```php
+'npx_mcp_server' => [
+    'type'          => Transporters::STDIO,
+    'command'       => ['npx', '-y', '@modelcontextprotocol/server-memory'],
+    'timeout'       => 30,               // seconds, applies to waitForResponse
+    'cwd'           => base_path(),
+    'env'           => [],               // PATH is auto-merged
+    'startup_delay' => 50,               // ms after process start
+    'poll_interval' => 10,               // ms between getIncrementalOutput() polls
+],
+```
+
+The factory dispatches on `type`; everything else is transport-specific and only the relevant transporter inspects its keys.
+
+---
+
+## Exception model
+
+Two exceptions, both extending `\Exception`:
+
+- `Redberry\MCPClient\Core\Exceptions\TransporterRequestException` — every transport-layer failure: HTTP errors, JSON-RPC errors, malformed responses, timeouts, eventual session loss. Code preserves the spec JSON-RPC error code where applicable.
+- `Redberry\MCPClient\Core\Exceptions\ServerConfigurationException` — invalid config shape detected at construction (currently only thrown by `StdioTransporter` for missing `command`).
+
+`MCPClient::ensureConfigurationValidity()` throws a vanilla `\RuntimeException` for unknown server names — that one's a programmer error, not a runtime IO problem.
+
+Callers should catch `TransporterRequestException` for IO failures. They should never need to catch raw `GuzzleException` or `JsonException` — those are wrapped at the transport boundary.
+
+---
+
+## Testing strategy
+
+- **Pest** with Orchestra Testbench (`tests/TestCase.php`).
+- **No real network or subprocesses.** HTTP transporter tests inject a Guzzle `Client` wrapping `MockHandler`. SSE parser tests feed a `StreamInterface` mock. STDIO transporter tests use stub commands or fixtures, not real `npx`.
+- **Architecture rule.** `tests/ArchTest.php` forbids `dd`, `dump`, `ray` in source files.
+- **Constructor injection over reflection.** `HttpTransporter` accepts an optional Guzzle client specifically so tests don't need `ReflectionClass`. New tests should follow that pattern (legacy reflection-based helpers are tracked for removal in ROADMAP P4).
+- **Real-shape fixtures** live in `tests/Datasets/` (e.g. `GithubResponseExample.php`).
+
+See [`.claude/rules/testing.md`](.claude/rules/testing.md) for the full testing rules.
+
+---
+
+## Adding a new transport
+
+1. Create `src/Core/Transporters/MyTransporter.php` implementing `Transporter`.
+2. Add a case to `src/Enums/Transporters.php`.
+3. Add a `match` arm to `src/Core/TransporterFactory::make()`.
+4. Document new config keys in `config/mcp-client.php` with inline comments.
+5. Write tests under `tests/Transporter/MyTransporterTest.php` covering happy path, error path, initialize handshake, and (if streaming) `$onEvent` invocation.
+6. Add a CHANGELOG entry under `## Unreleased`.
+
+See [`.claude/rules/transporters.md`](.claude/rules/transporters.md) for the full contract obligations.
+
+---
+
+## What's intentionally not here
+
+Documented in [ROADMAP.md:98–102](ROADMAP.md):
+
+- Long-lived `GET /` SSE channel for unsolicited server→client notifications.
+- `Last-Event-ID` resumability on Streamable HTTP.
+- Sampling, completions, elicitation flows beyond `tools/list`, `tools/call`, `resources/list`, `resources/read`.
+- Server capabilities introspection.
+
+The `MCPClient` API is deliberately narrow — request/response only, four verbs. Widening it requires a ROADMAP item first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+## Project Overview
+
+**MCP Client for Laravel** (`redberry/mcp-client-laravel`) is a Laravel-native client for Model Context Protocol (MCP) servers. It speaks JSON-RPC 2.0 over two transports — Streamable HTTP (spec `2025-03-26`) and STDIO — and exposes them through a single facade so a Laravel app can list/call tools, read resources, and observe streamed events from any MCP-compliant server defined in config.
+
+## Commands
+
+```bash
+composer test                          # Run Pest tests
+composer test-coverage                 # Tests with coverage
+composer analyse                       # PHPStan (level 5, src + config)
+composer format                        # Laravel Pint
+bin/check                              # Pint → PHPStan → Pest in sequence (the local CI gate)
+vendor/bin/pest --filter="test name"   # Run a single test
+vendor/bin/pest tests/Transporter/     # Run a directory
+composer prepare                       # testbench package:discover (after dep changes)
+```
+
+CI runs Pint (`fix-php-code-style-issues.yml`), PHPStan (`phpstan.yml`), and Pest (`run-tests.yml`) on every push.
+
+## File Map
+
+```
+src/
+  MCPClient.php                        # User-facing client. connect() → tools()/resources()/callTool()/readResource()
+  MCPClientServiceProvider.php         # Spatie PackageServiceProvider — config + binding live here only
+  Collection.php                       # Lightweight Countable/IteratorAggregate wrapper for tools/resources lists
+  Contracts/
+    MCPClient.php                      # Public client interface
+  Core/
+    TransporterFactory.php             # Maps Transporters enum → concrete transporter (the only place that does)
+    Transporters/
+      Transporter.php                  # Single-method contract: request(string $action, array $params, ?callable $onEvent): array
+      HttpTransporter.php              # Streamable HTTP (Guzzle); content-negotiates JSON vs SSE per request
+      StdioTransporter.php             # Symfony Process; line-delimited JSON-RPC over stdin/stdout
+    Http/
+      SseStreamParser.php              # Streaming SSE → JSON-RPC decoder, surfaces every event via $onEvent
+    Exceptions/
+      TransporterRequestException.php  # Throw this on any transport-level failure
+      ServerConfigurationException.php # Throw this on invalid server config
+  Enums/Transporters.php               # 'http' | 'stdio'
+  Facades/MCPClient.php                # Laravel facade wrapping Redberry\MCPClient\MCPClient
+  Commands/MCPClientCommand.php        # Artisan command stub
+
+config/mcp-client.php                  # Server map; published via `vendor:publish --tag=mcp-client-config`
+tests/
+  Transporter/                         # HTTP/STDIO/factory tests
+  Http/SseStreamParserTest.php         # SSE parser tests
+  MCPClient/MCPClientTest.php          # Facade-level integration tests
+  Helpers/CollectionTest.php           # Collection unit tests
+  Datasets/                            # Shared fixtures (e.g. real-shape responses)
+  Pest.php, TestCase.php, ArchTest.php # Pest bootstrap, Orchestra base, debug-call arch rule
+ROADMAP.md                             # Authoritative list of P0–P6 follow-ups; each item ships as its own PR
+```
+
+## Architecture
+
+### Request flow
+
+```
+MCPClient::callTool('x', $args)
+  → Transporter::request('tools/call', ['name' => 'x', 'arguments' => $args], $onEvent)
+    → preparePayload()  // {jsonrpc:"2.0", id, method, params}
+    → POST (HTTP) or stdin write (STDIO)
+    → parseResponse / waitForResponse
+    → returns the JSON-RPC `result` (array)
+```
+
+`MCPClient::tools()` and `resources()` call `request()` directly (no `$onEvent`), since list calls don't stream meaningfully.
+
+### HTTP transport (`HttpTransporter`)
+
+Implements MCP's [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). Lifecycle:
+
+1. **`initializeSession()`** — runs once per instance before the first user request. POSTs an `initialize` payload, captures `mcp-session-id` from the response header, and replays it on every subsequent request via `mcp-session-id` header. *(See ROADMAP P0 — the current payload is missing `protocolVersion`/`capabilities`/`clientInfo` and the `notifications/initialized` follow-up.)*
+2. Every request advertises `Accept: application/json, text/event-stream`. The server picks per-call.
+3. **`parseResponse()`** branches on the response Content-Type: `text/event-stream` → `SseStreamParser::parse()`; anything else → single JSON decode.
+4. JSON-RPC errors throw `TransporterRequestException` with the spec error code.
+
+### STDIO transport (`StdioTransporter`)
+
+Spawns the configured command via Symfony `Process`. Lifecycle:
+
+1. **`start()`** — lazy. On first `request()`, starts the process, sleeps `startup_delay` ms, then sends both `initialize` and `initialized` payloads back-to-back.
+2. **`request()`** writes one line of JSON to stdin and calls `waitForResponse($id)`, which polls `getIncrementalOutput()` every `poll_interval` ms until it sees a JSON line whose `id` matches.
+3. **`__destruct()`** stops the process and closes the input stream.
+
+Note: STDIO **ignores** `$onEvent` — the contract says so, but it's not invoked from STDIO because we don't decode intermediate notifications today (see ROADMAP P6).
+
+### SSE parsing (`SseStreamParser`)
+
+Reads the Guzzle `StreamInterface` in 8KB chunks, drains complete `\n`-terminated lines, accumulates `data:` continuations into one event, and dispatches on blank-line boundaries. For every decoded JSON-RPC message it calls `$onEvent` (notifications, progress, final result alike); the result-bearing payload becomes the return value. Stream ending without a result throws.
+
+### Service binding
+
+`MCPClientServiceProvider::packageBooted()` binds `Redberry\MCPClient\MCPClient` with the resolved `mcp-client.servers` array. **This is the only place in the package that reads `config()` or wires concrete classes.** Everywhere else takes its config via constructor.
+
+## Conventions
+
+- **Namespace:** `Redberry\MCPClient`
+- **`declare(strict_types=1);`** at the top of every new PHP file (some older files don't have it — add it when you touch them)
+- **Constructor injection only** — no `app()` / `resolve()` / facades inside core services
+- **`config()` only in the service provider and `config/mcp-client.php`**, never in transporters or services
+- **Throw `TransporterRequestException`** for any transport-layer failure (HTTP error, JSON-RPC error, malformed response, timeout). Throw `ServerConfigurationException` for invalid config shapes.
+- **JSON-RPC `id` generation** must be a per-instance incrementing counter, like `StdioTransporter::$requestId` (HTTP currently uses `random_int` — see ROADMAP P5)
+- **`PROTOCOL_VERSION` belongs in one place** — once it's promoted to the `Transporter` interface or a shared value object (ROADMAP P0), reference it from both transporters
+- **Conventional Commits:** `feat:`, `fix:`, `chore:`, `test:`, `refactor:`, `docs:`
+- **One ROADMAP item per PR** unless P4–P6 are bundled (see ROADMAP.md for the suggested PR order)
+
+## Don't
+
+- Don't bypass `Transporter::request()` — it's the only IO seam and the contract every transport implements
+- Don't add new code paths that read `config()` outside the service provider
+- Don't hardcode the protocol version a second time (`'2024-11-05'` in `StdioTransporter` is already a known issue — don't replicate the pattern)
+- Don't hardcode `clientInfo.version` (`'0.1.0'` in `StdioTransporter::sendInitializeRequests()` is wrong — pull from `\Composer\InstalledVersions::getPrettyVersion('redberry/mcp-client-laravel')` once it's centralized)
+- Don't introduce real network or real subprocesses in tests — mock Guzzle with `MockHandler`, mock STDIO with fixtures
+- Don't use `ReflectionClass` to set up transporter state in new tests — use constructor injection (HTTP transporter accepts `?GuzzleClient`)
+- Don't use `random_int` for new request id generators — use an incrementing counter
+- Don't add `dd()`, `dump()`, `ray()`, or `var_dump()` in committed code (the arch test in `tests/ArchTest.php` will fail)
+- Don't widen the changelog scope of P0 by combining it with other ROADMAP items (per ROADMAP.md:96)
+- Don't start work on resumability, `Last-Event-ID`, or a long-lived `GET /` SSE channel without checking first (out-of-scope per ROADMAP.md:98–102)
+
+## Definition of Done
+
+1. `bin/check` passes locally (Pint + PHPStan + Pest, in that order)
+2. New code paths have tests; new public APIs have at least one happy-path test and one error-path test
+3. `CHANGELOG.md` updated under `## Unreleased` with an `Added`/`Changed`/`Fixed` entry for any user-facing change
+4. README updated only if the public API or configuration shape changes
+5. ROADMAP item ticked off (or moved/edited if scope shifted)
+6. Conventional Commits format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,183 @@
+# Contributing
+
+Thanks for taking the time to contribute. This document covers everything you need to get a change merged into `redberry/mcp-client-laravel`.
+
+If you're an AI agent working in this repo, also read [CLAUDE.md](CLAUDE.md), [ARCHITECTURE.md](ARCHITECTURE.md), and the rule files under [.claude/rules/](.claude/rules/).
+
+---
+
+## Local setup
+
+The package is developed inside a Laravel host app via path repository (composer) — but you can also clone it standalone and use Orchestra Testbench (which is wired in via `composer.json`).
+
+### Standalone
+
+```bash
+git clone https://github.com/redberryproducts/mcp-client-laravel.git
+cd mcp-client-laravel
+composer install
+composer test          # confirms the toolchain works
+```
+
+### Inside a host app (path repository)
+
+```bash
+# in your host app's composer.json
+{
+  "repositories": [
+    { "type": "path", "url": "packages/redberry/laravel-mcp-client" }
+  ]
+}
+```
+
+```bash
+composer require redberry/mcp-client-laravel:@dev
+```
+
+Symlinked path repositories mean edits in `packages/redberry/laravel-mcp-client/` are immediately picked up by the host app — no `composer update` cycle.
+
+### Tooling versions
+
+- PHP **8.3** or **8.4**
+- Laravel **10**, **11**, or **12** (Illuminate contracts `^10.0||^11.0||^12.0`)
+- Composer 2.x
+
+CI runs Pint, PHPStan, and Pest on every push.
+
+---
+
+## Workflow
+
+### 1. Pick a task
+
+Most non-trivial work is queued in [ROADMAP.md](ROADMAP.md) as P0 → P6. **Pick the lowest-numbered unstarted item unless you have a specific reason to skip ahead.** Each ROADMAP item ships as **its own PR** — don't bundle them. P0 in particular must stand alone (it's the spec-compliance fix and needs to be a clean entry in the changelog).
+
+If you want to do something not in the ROADMAP, open an issue first to discuss scope. The package has a deliberately narrow surface; new public API requires alignment.
+
+### 2. Branch
+
+Create a topic branch off `main`:
+
+```bash
+git checkout -b fix/initialize-handshake     # or feat/, refactor/, docs/, test/, chore/
+```
+
+We don't enforce a strict naming scheme, but match the type to the Conventional Commits prefix you'll use.
+
+### 3. Make your change
+
+Read [ARCHITECTURE.md](ARCHITECTURE.md) before touching anything in `src/Core/`. The transport contract and the SSE parser are the load-bearing pieces — small changes there ripple everywhere.
+
+Specific rule files for the area you're working in:
+
+- Adding/modifying a transport → [.claude/rules/transporters.md](.claude/rules/transporters.md)
+- Anything spec-related (`initialize`, JSON-RPC envelope, error codes) → [.claude/rules/mcp-spec.md](.claude/rules/mcp-spec.md)
+- Anything test-related → [.claude/rules/testing.md](.claude/rules/testing.md)
+
+### 4. Add tests
+
+Every change needs at least one test. Concretely:
+
+- **New public API** → at least one happy-path test and one error-path test.
+- **Bug fix** → a regression test that fails on `main` and passes on your branch.
+- **Refactor** → existing tests must continue to pass; add a new test if the refactor uncovers an untested seam.
+
+Pest is the framework. Tests run against Orchestra Testbench. Mock Guzzle with `MockHandler`. Don't introduce real network or real subprocesses. See [.claude/rules/testing.md](.claude/rules/testing.md) for the full set of testing rules.
+
+### 5. Run the local gate
+
+Before you push, run the same checks CI runs:
+
+```bash
+bin/check
+```
+
+This runs Pint → PHPStan → Pest in sequence. Any failure should be fixed before you push.
+
+You can also run them individually:
+
+```bash
+composer format       # Pint (fixes style)
+composer analyse      # PHPStan level 5
+composer test         # Pest
+```
+
+### 6. Update CHANGELOG and (if needed) README
+
+- **CHANGELOG.md** — every user-facing change gets an entry under `## Unreleased`, grouped under `Added` / `Changed` / `Fixed` / `Removed`. Internal refactors that don't affect users don't need an entry.
+- **README.md** — only update when the public API or configuration shape changes. README is for users; ARCHITECTURE.md and CLAUDE.md are for contributors and agents.
+- **ROADMAP.md** — tick off the item you completed (or move it / edit scope if it shifted during implementation).
+
+### 7. Commit
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add session-loss recovery to HttpTransporter
+fix: handle missing error.message in SseStreamParser
+chore: bump phpstan to v2
+test: cover initialize handshake on HttpTransporter
+refactor: migrate HttpTransporterTest off ReflectionClass helper
+docs: clarify $onEvent semantics on STDIO
+```
+
+One logical change per commit. If you find yourself writing `feat: X and Y`, split it.
+
+### 8. Open a PR
+
+Push your branch and open a PR against `main`. The PR description should:
+
+- Link the ROADMAP item if applicable (e.g. `Closes ROADMAP P3`).
+- Summarize what changed and why — focus on **why**, since the code already shows what.
+- Note any spec sections referenced (link them — see [.claude/rules/mcp-spec.md](.claude/rules/mcp-spec.md)).
+- Include a brief test plan: which scenarios you covered, anything you couldn't test and why.
+
+CI runs Pint, PHPStan, and Pest. All three must be green before review.
+
+---
+
+## Code style
+
+- `declare(strict_types=1);` at the top of every new PHP file. Add it when you touch an older file that doesn't have it.
+- Constructor injection only — no `app()`, `resolve()`, or facades inside core services.
+- `config()` is read **only** in `MCPClientServiceProvider` and `config/mcp-client.php`. Transporters and services receive config via constructor.
+- Throw `TransporterRequestException` for any transport-layer failure. Throw `ServerConfigurationException` for invalid config shapes. Don't leak raw `GuzzleException` or `JsonException` past the transport boundary.
+- Return types and parameter types on every public method.
+- No `dd()`, `dump()`, `ray()`, or `var_dump()` in committed code. The arch test in `tests/ArchTest.php` will fail.
+- Pint enforces formatting — let it. Don't hand-roll style choices.
+
+---
+
+## Reporting bugs
+
+Open a GitHub issue with:
+
+- The Laravel version, PHP version, and package version
+- The transport (`http` or `stdio`) and the relevant config block (redact tokens)
+- A minimal reproduction — ideally a failing test
+- The actual exception message and stack trace
+
+For HTTP issues, the response Content-Type and a sanitized request/response body help a lot.
+
+---
+
+## Reporting security vulnerabilities
+
+Please review [our security policy](../../security/policy) on how to report security vulnerabilities. **Don't open public issues for security problems.**
+
+---
+
+## Releasing (maintainers only)
+
+1. Move everything under `## Unreleased` in `CHANGELOG.md` to a new `## [x.y.z] - YYYY-MM-DD` heading.
+2. Tag the commit: `git tag -a vX.Y.Z -m "vX.Y.Z"`.
+3. Push the tag: `git push origin vX.Y.Z`. Packagist picks it up automatically.
+4. Create a GitHub Release pointing at the tag with the changelog excerpt as the body.
+
+Versioning follows [SemVer](https://semver.org/). The package is pre-1.0; minor versions can include breaking changes if necessary, but flag them clearly in the changelog.
+
+---
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,102 @@
+# Roadmap
+
+Follow-up work tracked after PR #33 (Streamable HTTP transport). Tasks are ordered by priority — please complete them in order and ship each as its own PR for clean review unless noted otherwise.
+
+All file paths below are relative to the package root.
+
+---
+
+## P0 — Spec-correct `initialize` handshake for `HttpTransporter`
+
+**Problem.** `HttpTransporter::initializeSession()` (`src/Core/Transporters/HttpTransporter.php`, lines 34–63) currently sends a bare `initialize` payload (just `method`, empty `params`). The MCP spec requires `protocolVersion`, `capabilities`, and `clientInfo`, plus a follow-up `notifications/initialized` notification. Strict-spec servers (the official TS reference, Anthropic's MCP servers, others) will reject what we send today. STDIO already does this correctly — see `StdioTransporter::sendInitializeRequests()` (`src/Core/Transporters/StdioTransporter.php`, lines 153–185) for the exact shape.
+
+**Tasks.**
+1. In `initializeSession()`, build the initialize payload with `protocolVersion`, `capabilities` (empty object is fine), and `clientInfo` (`name`, `version`) — match the STDIO shape.
+2. After capturing `mcp-session-id` from the response, send a second POST with `notifications/initialized` and no `id` field (it's a notification, not a request — server doesn't reply).
+3. Promote the `PROTOCOL_VERSION` constant to a shared location (e.g. a `Core/Mcp.php` value object or a constant on the `Transporter` interface). Both transporters should reference the same value — today STDIO has `'2024-11-05'` hardcoded; pick the version that matches the Streamable HTTP spec we're implementing (`2025-03-26`) and align both transporters.
+4. The `clientInfo.version` should not be hardcoded (`'0.1.0'` is wrong already on STDIO). Pull it from `composer.json` via `\Composer\InstalledVersions::getPrettyVersion('redberry/mcp-client-laravel')` with a fallback string.
+
+**Acceptance.**
+- New tests covering: (a) initialize payload contains all three required fields, (b) `notifications/initialized` is sent after a successful initialize, (c) the notification has no `id`.
+- Existing tests still pass; STDIO and HTTP both report the same `protocolVersion`.
+- Manual smoke test against a real MCP server (e.g. `@modelcontextprotocol/server-everything` over HTTP) — confirm `tools/list` succeeds.
+
+---
+
+## P1 — Defensive error-message handling in `SseStreamParser`
+
+**Problem.** `SseStreamParser::dispatch()` (`src/Core/Http/SseStreamParser.php`, lines 127–130) builds the exception message as `"JSON-RPC error: {$decoded['error']['message']}"`. If a server sends `{"error":{"code":-32601}}` without a `message` key, this emits a PHP warning and produces an empty-string error. STDIO already does this defensively in `StdioTransporter` (lines 239–240).
+
+**Task.** Mirror the STDIO pattern: `$message = $decoded['error']['message'] ?? 'Unknown JSON-RPC error';`. Add a regression test feeding an SSE event with a missing `message` field.
+
+**Acceptance.** New test asserts the parser throws `TransporterRequestException` with `'Unknown JSON-RPC error'` (and the code, when present) when only `code` is sent.
+
+---
+
+## P2 — SSE read-timeout / wedge protection
+
+**Problem.** `HttpTransporter` passes `timeout` to Guzzle, but that bounds connection/request setup, not body reads on a streamed response. A misbehaving server that keeps the connection open while sending nothing will park a queue worker indefinitely on `$stream->read()` in `SseStreamParser::parse()` (`src/Core/Http/SseStreamParser.php`, lines 41–42).
+
+**Tasks.**
+1. Add an optional `read_timeout` config key on `HttpTransporter` (default e.g. 60s). Document it in `config/mcp-client.php`.
+2. Pass it into `SseStreamParser::parse()` as a parameter.
+3. In the parse loop, track `microtime(true)` per iteration and throw `TransporterRequestException` ("SSE read timed out after Xs") if the time since the *last received chunk* exceeds the timeout. Reset the clock whenever a chunk arrives — a long-running operation that streams progress events should not time out as long as something is coming through.
+
+**Acceptance.**
+- Test using a `StreamInterface` mock that returns `''` from `read()` (no data) and never EOFs — assert it throws within roughly the configured timeout.
+- Test that progress events reset the clock (stream returns chunks slower than the timeout but never exceeds it between chunks).
+
+---
+
+## P3 — Session-loss recovery
+
+**Problem.** `HttpTransporter::$initialized` and `$sessionId` are sticky on the instance. If the server tears down the session (per the MCP spec, this surfaces as HTTP 404 with a known error code, or a JSON-RPC error indicating "session not found"), we'll keep posting the stale `mcp-session-id` until the worker restarts. Realistic for queue workers and long-running daemons.
+
+**Tasks.**
+1. In `parseResponse()` / the request flow, detect session-loss responses (HTTP 404 from the server, *or* a JSON-RPC error with the spec's session-not-found code — check the 2025-03-26 spec for the exact code).
+2. On detection: clear `$sessionId`, set `$initialized = false`, then retry the original request *once*. If the retry also fails for the same reason, surface as `TransporterRequestException`.
+3. Add a `max_session_retries` config knob (default 1) so the behavior is overridable.
+
+**Acceptance.** Test simulates: first request succeeds → second request returns 404 → transporter automatically re-initializes and retries → returns the third response. Also test the "retry also fails" path throws.
+
+---
+
+## P4 — Cleanup: migrate reflection-based test setup
+
+**Problem.** `createTransporterWithMockedSession()` in `tests/Transporter/HttpTransporterTest.php` (lines 16–38) uses `ReflectionClass` to poke private state. The new constructor-injection pattern from the same file (`client can be injected via constructor (no reflection needed)`, lines 288–302) is much cleaner.
+
+**Task.** Migrate every test that calls `createTransporterWithMockedSession()` to use constructor injection plus a real first call that primes the `initialize` exchange (you can add a tiny helper that returns `[$transporter, $mockClient]` and stubs the initialize POST). Delete the old helper. No behavior changes — just a refactor.
+
+**Acceptance.** No `ReflectionClass`/`ReflectionMethod` calls remain in `HttpTransporterTest.php` for state-setup purposes (testing `private` *methods* via reflection — `preparePayload`, `generateId`, `getClientBaseConfig` — is fine to keep). All tests still pass.
+
+---
+
+## P5 — Cleanup: switch HTTP request IDs to an incrementing counter
+
+**Problem.** `HttpTransporter::generateId()` (`src/Core/Transporters/HttpTransporter.php`, lines 144–151) uses `random_int(1, 1_000_000)`. Birthday-paradox collisions become non-trivial over a long-lived session (~1-in-1000 chance after 1k requests). STDIO uses `++$this->requestId`, which is the right pattern.
+
+**Task.** Replace with a per-instance incrementing counter, matching STDIO. Keep the `id_type` config (int vs string) — just change the source of the number. Update tests accordingly.
+
+**Acceptance.** Two sequential requests on the same transporter instance produce IDs 1 and 2 (or "1" and "2" with `id_type=string`).
+
+---
+
+## P6 — Document `$onEvent` is a no-op on STDIO
+
+**Problem.** `StdioTransporter::request()` (`src/Core/Transporters/StdioTransporter.php`, line 80) accepts `$onEvent` and silently ignores it. The interface docblock mentions this, but a README user reading the streaming-callback example may not realize it depends on the active transport.
+
+**Task.** Add a one-paragraph note in the README, immediately after the `$onEvent` example, stating that the callback is only invoked when the connected server returns `text/event-stream`; with the STDIO transport, or when an HTTP server returns a single JSON response, the callback fires zero times.
+
+**Acceptance.** README change merged. No code changes required.
+
+---
+
+## Suggested PR order
+
+P0 → P1 → P2 → P3 → P4 → P5 → P6. P0–P3 should each be its own PR; P4–P6 can be bundled if convenient. Don't combine P0 with anything else — it's the spec-compliance fix and needs to stand on its own in the changelog.
+
+## Out of scope (do not start without checking first)
+
+- Long-lived `GET /` SSE channel for unsolicited server→client notifications.
+- `Last-Event-ID` resumability.
+- The Pint config drift between fresh-clone and symlinked-workspace runs (separate investigation).


### PR DESCRIPTION
Adds the docs an AI agent or new contributor needs to be productive in this repo without reading every source file first.

- `CLAUDE.md` + `AGENTS.md` — overview, commands, file map, conventions, don'ts. AGENTS.md is just a pointer so non-Claude tools (Codex, Cursor, Aider) pick it up too.
- `ARCHITECTURE.md` — layers, request flow, HTTP/STDIO/SSE lifecycles with the rationale behind the non-obvious bits (lazy initialize, startup delay, polling vs blocking reads).
- `CONTRIBUTING.md` — local setup, the `bin/check` gate, ROADMAP-per-PR scoping, Conventional Commits, release flow. The README already linked to this file but it didn't exist.
- `.claude/rules/{testing,transporters,mcp-spec}.md` — durable rules per area, separate from ROADMAP (which is "what to do next").

No code changes. Cross-references the existing ROADMAP items (P0–P6) so docs and roadmap stay coherent.