### PR TITLE
fix: spec-correct initialize handshake on Streamable HTTP transport

### DIFF
--- a/.claude/rules/mcp-spec.md
+++ b/.claude/rules/mcp-spec.md
@@ -5,7 +5,7 @@ This package targets the Model Context Protocol spec. Treat the spec as authorit
 ## Pinned spec version
 
 - **HTTP transport:** [`2025-03-26` Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). This is the only HTTP shape we implement.
-- **STDIO transport:** Currently uses `protocolVersion: '2024-11-05'` in `StdioTransporter::PROTOCOL_VERSION`. ROADMAP P0 promotes `PROTOCOL_VERSION` to a single shared location and aligns both transporters to `2025-03-26`. Do not introduce a third version.
+- **STDIO transport:** Both transporters reference `Redberry\MCPClient\Core\Mcp::PROTOCOL_VERSION` (`2025-03-26`). Don't introduce a per-class version constant.
 
 When you reach for the spec, link the section anchor in your PR description so reviewers can verify against the same revision you used.
 
@@ -51,7 +51,7 @@ Required for **both** transports before any user-issued request. Two messages, i
 
 - Strict-spec servers (Anthropic's reference servers, the official TS reference) reject an `initialize` payload missing any of `protocolVersion`, `capabilities`, `clientInfo`.
 - The HTTP transport additionally captures `mcp-session-id` from the `initialize` response headers and replays it on every subsequent request as a header.
-- `clientInfo.version` must come from `\Composer\InstalledVersions::getPrettyVersion('redberry/mcp-client-laravel')`, not a hardcoded string.
+- Source `clientInfo` from `Redberry\MCPClient\Core\Mcp::clientInfo()` — it already handles the composer version lookup.
 
 ## Streamable HTTP specifics
 

--- a/.claude/rules/transporters.md
+++ b/.claude/rules/transporters.md
@@ -14,8 +14,8 @@ When adding a new transport (e.g. WebSocket) or modifying `HttpTransporter` / `S
 
 6. Run the MCP `initialize` handshake exactly once per instance, lazily on the first user request. Don't run it in the constructor.
 7. The initialize payload must include `protocolVersion`, `capabilities` (empty object `(object)[]` is fine), and `clientInfo` (`name`, `version`). After a successful `initialize`, send a `notifications/initialized` notification (no `id` field — it's not a request). See `mcp-spec.md` for the exact shape.
-8. Reference a single shared `PROTOCOL_VERSION` constant — once it's promoted to the `Transporter` interface or a `Core/Mcp.php` value object (per ROADMAP P0), use it. Don't redeclare a per-class constant.
-9. `clientInfo.version` must be sourced from the package's installed version, not hardcoded. Use `\Composer\InstalledVersions::getPrettyVersion('redberry/mcp-client-laravel')` with a string fallback.
+8. Reference `Redberry\MCPClient\Core\Mcp::PROTOCOL_VERSION` for the protocol version. Don't redeclare a per-class constant.
+9. `clientInfo` (both `name` and `version`) must come from `Redberry\MCPClient\Core\Mcp::clientInfo()`, which already handles version resolution and the missing-package fallback.
 
 ## Request IDs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,9 @@ All notable changes to `mcp-client-laravel` will be documented in this file.
 ### Changed
 
 - `composer.json` now explicitly requires `guzzlehttp/guzzle` and `psr/http-message`, which the HTTP transporter has always relied on transitively.
+- Both transporters now report `protocolVersion: 2025-03-26` and source `clientInfo.version` from the installed composer package version (was hardcoded `0.1.0` on STDIO). Shared in a new `Redberry\MCPClient\Core\Mcp` value class.
+
+### Fixed
+
+- Spec-correct `initialize` handshake on the HTTP transporter — payload now includes `protocolVersion`, `capabilities`, and `clientInfo`, and the required `notifications/initialized` notification is sent before the first user request. Strict-spec MCP servers (the official TS reference, Anthropic's servers) previously rejected the bare initialize.
+- STDIO transporter sent the post-initialize notification with method `initialized`; renamed to spec-correct `notifications/initialized`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ MCPClient::callTool('x', $args)
 
 Implements MCP's [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). Lifecycle:
 
-1. **`initializeSession()`** — runs once per instance before the first user request. POSTs an `initialize` payload, captures `mcp-session-id` from the response header, and replays it on every subsequent request via `mcp-session-id` header. *(See ROADMAP P0 — the current payload is missing `protocolVersion`/`capabilities`/`clientInfo` and the `notifications/initialized` follow-up.)*
+1. **`initializeSession()`** — runs once per instance before the first user request. POSTs an `initialize` payload, captures `mcp-session-id` from the response header, and replays it on every subsequent request via `mcp-session-id` header.
 2. Every request advertises `Accept: application/json, text/event-stream`. The server picks per-call.
 3. **`parseResponse()`** branches on the response Content-Type: `text/event-stream` → `SseStreamParser::parse()`; anything else → single JSON decode.
 4. JSON-RPC errors throw `TransporterRequestException` with the spec error code.
@@ -102,7 +102,7 @@ Reads the Guzzle `StreamInterface` in 8KB chunks, drains complete `\n`-terminate
 - **`config()` only in the service provider and `config/mcp-client.php`**, never in transporters or services
 - **Throw `TransporterRequestException`** for any transport-layer failure (HTTP error, JSON-RPC error, malformed response, timeout). Throw `ServerConfigurationException` for invalid config shapes.
 - **JSON-RPC `id` generation** must be a per-instance incrementing counter, like `StdioTransporter::$requestId` (HTTP currently uses `random_int` — see ROADMAP P5)
-- **`PROTOCOL_VERSION` belongs in one place** — once it's promoted to the `Transporter` interface or a shared value object (ROADMAP P0), reference it from both transporters
+- **`PROTOCOL_VERSION` belongs in one place** — reference `Redberry\MCPClient\Core\Mcp::PROTOCOL_VERSION` from both transporters; don't redeclare per-class.
 - **Conventional Commits:** `feat:`, `fix:`, `chore:`, `test:`, `refactor:`, `docs:`
 - **One ROADMAP item per PR** unless P4–P6 are bundled (see ROADMAP.md for the suggested PR order)
 
@@ -111,7 +111,7 @@ Reads the Guzzle `StreamInterface` in 8KB chunks, drains complete `\n`-terminate
 - Don't bypass `Transporter::request()` — it's the only IO seam and the contract every transport implements
 - Don't add new code paths that read `config()` outside the service provider
 - Don't hardcode the protocol version a second time (`'2024-11-05'` in `StdioTransporter` is already a known issue — don't replicate the pattern)
-- Don't hardcode `clientInfo.version` (`'0.1.0'` in `StdioTransporter::sendInitializeRequests()` is wrong — pull from `\Composer\InstalledVersions::getPrettyVersion('redberry/mcp-client-laravel')` once it's centralized)
+- Don't hardcode `clientInfo.version` — use `Redberry\MCPClient\Core\Mcp::clientInfo()` which sources the version from the installed composer package.
 - Don't introduce real network or real subprocesses in tests — mock Guzzle with `MockHandler`, mock STDIO with fixtures
 - Don't use `ReflectionClass` to set up transporter state in new tests — use constructor injection (HTTP transporter accepts `?GuzzleClient`)
 - Don't use `random_int` for new request id generators — use an incrementing counter

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ All file paths below are relative to the package root.
 
 ---
 
-## P0 — Spec-correct `initialize` handshake for `HttpTransporter`
+## ~~P0 — Spec-correct `initialize` handshake for `HttpTransporter`~~ ✅ Done
 
 **Problem.** `HttpTransporter::initializeSession()` (`src/Core/Transporters/HttpTransporter.php`, lines 34–63) currently sends a bare `initialize` payload (just `method`, empty `params`). The MCP spec requires `protocolVersion`, `capabilities`, and `clientInfo`, plus a follow-up `notifications/initialized` notification. Strict-spec servers (the official TS reference, Anthropic's MCP servers, others) will reject what we send today. STDIO already does this correctly — see `StdioTransporter::sendInitializeRequests()` (`src/Core/Transporters/StdioTransporter.php`, lines 153–185) for the exact shape.
 

--- a/src/Core/Mcp.php
+++ b/src/Core/Mcp.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redberry\MCPClient\Core;
+
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+
+final class Mcp
+{
+    public const PROTOCOL_VERSION = '2025-03-26';
+
+    public const CLIENT_NAME = 'mcp-client-laravel';
+
+    public const PACKAGE_NAME = 'redberry/mcp-client-laravel';
+
+    public const FALLBACK_VERSION = '0.0.0-dev';
+
+    /**
+     * @return array{name: string, version: string}
+     */
+    public static function clientInfo(): array
+    {
+        return [
+            'name' => self::CLIENT_NAME,
+            'version' => self::resolveClientVersion(),
+        ];
+    }
+
+    private static function resolveClientVersion(): string
+    {
+        try {
+            $version = InstalledVersions::getPrettyVersion(self::PACKAGE_NAME);
+        } catch (OutOfBoundsException) {
+            return self::FALLBACK_VERSION;
+        }
+
+        return $version ?? self::FALLBACK_VERSION;
+    }
+}

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redberry\MCPClient\Core\Transporters;
 
 use GuzzleHttp\Client;
@@ -9,6 +11,7 @@ use JsonException;
 use Psr\Http\Message\ResponseInterface;
 use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
 use Redberry\MCPClient\Core\Http\SseStreamParser;
+use Redberry\MCPClient\Core\Mcp;
 
 class HttpTransporter implements Transporter
 {
@@ -27,7 +30,9 @@ class HttpTransporter implements Transporter
 
     /**
      * Perform the "initialize" handshake and capture the MCP session id.
-     * Called once before the first user-issued request.
+     * Called once before the first user-issued request. Per the MCP spec
+     * (2025-03-26) we follow the initialize request with a
+     * `notifications/initialized` notification before any user request.
      *
      * @throws TransporterRequestException
      */
@@ -37,11 +42,9 @@ class HttpTransporter implements Transporter
             return;
         }
 
-        $payload = $this->preparePayload('initialize');
-
         try {
             $response = $this->client->request('POST', '', [
-                'json' => $payload,
+                'json' => $this->prepareInitializePayload(),
                 'timeout' => $this->config['timeout'] ?? 30,
                 'stream' => true,
                 'headers' => $this->buildRequestHeaders(),
@@ -57,6 +60,23 @@ class HttpTransporter implements Transporter
         $hdr = $response->getHeader('mcp-session-id');
         if (! empty($hdr)) {
             $this->sessionId = $hdr[0];
+        }
+
+        try {
+            $this->client->request('POST', '', [
+                'json' => $this->prepareInitializedNotification(),
+                'timeout' => $this->config['timeout'] ?? 30,
+                'stream' => true,
+                'headers' => $this->buildRequestHeaders(),
+            ]);
+        } catch (GuzzleException $e) {
+            // Leave $initialized = false so the next request retries the handshake.
+            $this->sessionId = null;
+            throw new TransporterRequestException(
+                "HTTP error sending notifications/initialized: {$e->getMessage()}",
+                (int) $e->getCode(),
+                $e
+            );
         }
 
         $this->initialized = true;
@@ -158,6 +178,29 @@ class HttpTransporter implements Transporter
             // Empty params must JSON-encode as {} (object), not [] (array), so spec-strict servers accept them.
             'params' => $params === [] ? (object) [] : $params,
             'id' => $this->generateId(),
+        ];
+    }
+
+    private function prepareInitializePayload(): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id' => $this->generateId(),
+            'method' => 'initialize',
+            'params' => [
+                'protocolVersion' => Mcp::PROTOCOL_VERSION,
+                'capabilities' => (object) [],
+                'clientInfo' => Mcp::clientInfo(),
+            ],
+        ];
+    }
+
+    private function prepareInitializedNotification(): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'method' => 'notifications/initialized',
+            'params' => (object) [],
         ];
     }
 

--- a/src/Core/Transporters/StdioTransporter.php
+++ b/src/Core/Transporters/StdioTransporter.php
@@ -6,6 +6,7 @@ namespace Redberry\MCPClient\Core\Transporters;
 
 use Redberry\MCPClient\Core\Exceptions\ServerConfigurationException;
 use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
+use Redberry\MCPClient\Core\Mcp;
 use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
@@ -16,8 +17,6 @@ class StdioTransporter implements Transporter
     private InputStream $inputStream;
 
     private int $requestId = 0;
-
-    private const PROTOCOL_VERSION = '2024-11-05';
 
     private const DEFAULT_TIMEOUT = 3;
 
@@ -152,24 +151,20 @@ class StdioTransporter implements Transporter
 
     protected function sendInitializeRequests(): void
     {
-        $clientInfo = [
-            'name' => 'mcp-client-laravel',
-            'version' => '0.1.0',
-        ];
         $initPayloads = [
             [
                 'jsonrpc' => '2.0',
                 'id' => 'init',
                 'method' => 'initialize',
                 'params' => [
-                    'protocolVersion' => self::PROTOCOL_VERSION,
+                    'protocolVersion' => Mcp::PROTOCOL_VERSION,
                     'capabilities' => (object) [],
-                    'clientInfo' => $clientInfo,
+                    'clientInfo' => Mcp::clientInfo(),
                 ],
             ],
             [
                 'jsonrpc' => '2.0',
-                'method' => 'initialized',
+                'method' => 'notifications/initialized',
                 'params' => (object) [],
             ],
         ];

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -290,12 +290,21 @@ describe('HttpTransporter', function () {
         $transporter = new HttpTransporter([], $mockClient);
 
         $initResp = new Response(200, ['mcp-session-id' => 'sid-99', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp = new Response(202, [], '');
         $reqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => ['ok' => 1]]));
 
-        $mockClient->shouldReceive('request')->once()->with('POST', '', Mockery::type('array'))->andReturn($initResp);
         $mockClient->shouldReceive('request')
             ->once()
-            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['headers']['mcp-session-id'] ?? null) === 'sid-99'))
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp);
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp);
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['headers']['mcp-session-id'] ?? null) === 'sid-99'
+                && ($opts['json']['method'] ?? null) === 'ping'))
             ->andReturn($reqResp);
 
         expect($transporter->request('ping'))->toEqual(['ok' => 1]);
@@ -400,6 +409,7 @@ SSE;
         $transporter = new HttpTransporter([], $mockClient);
 
         $initResp = new Response(200, ['mcp-session-id' => 'session-xyz', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp = new Response(202, [], '');
         $reqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => ['after' => true]]));
 
         $mockClient->shouldReceive('request')
@@ -410,9 +420,132 @@ SSE;
 
         $mockClient->shouldReceive('request')
             ->once()
-            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['headers']['mcp-session-id'] ?? null) === 'session-xyz'))
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'
+                && ($opts['headers']['mcp-session-id'] ?? null) === 'session-xyz'))
+            ->andReturn($notifyResp);
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['headers']['mcp-session-id'] ?? null) === 'session-xyz'
+                && ($opts['json']['method'] ?? null) === 'after_init'))
             ->andReturn($reqResp);
 
         expect($transporter->request('after_init'))->toEqual(['after' => true]);
+    });
+
+    test('initialize payload contains protocolVersion, capabilities and clientInfo', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $captured = null;
+        $initResp = new Response(200, ['mcp-session-id' => 'sid', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp = new Response(202, [], '');
+        $reqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => ['ok' => true]]));
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(function ($opts) use (&$captured) {
+                if (($opts['json']['method'] ?? null) !== 'initialize') {
+                    return false;
+                }
+                $captured = $opts['json'];
+
+                return true;
+            }))
+            ->andReturn($initResp);
+        $mockClient->shouldReceive('request')->once()->andReturn($notifyResp);
+        $mockClient->shouldReceive('request')->once()->andReturn($reqResp);
+
+        $transporter->request('ping');
+
+        expect($captured['params']['protocolVersion'])->toBe(\Redberry\MCPClient\Core\Mcp::PROTOCOL_VERSION)
+            ->and($captured['params']['capabilities'])->toBeInstanceOf(stdClass::class)
+            ->and($captured['params']['clientInfo']['name'])->toBe('mcp-client-laravel')
+            ->and($captured['params']['clientInfo']['version'])->toBeString()
+            ->and($captured['params']['clientInfo']['version'])->not->toBe('');
+    });
+
+    test('notifications/initialized is sent after initialize, with the captured session id and no id field', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $captured = null;
+        $initResp = new Response(200, ['mcp-session-id' => 'sid-42', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp = new Response(202, [], '');
+        $reqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => []]));
+
+        $mockClient->shouldReceive('request')->once()->andReturn($initResp);
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(function ($opts) use (&$captured) {
+                if (($opts['json']['method'] ?? null) !== 'notifications/initialized') {
+                    return false;
+                }
+                $captured = $opts;
+
+                return true;
+            }))
+            ->andReturn($notifyResp);
+        $mockClient->shouldReceive('request')->once()->andReturn($reqResp);
+
+        $transporter->request('ping');
+
+        expect($captured['json'])->not->toHaveKey('id')
+            ->and($captured['headers']['mcp-session-id'])->toBe('sid-42')
+            ->and($captured['headers']['Accept'])->toBe('application/json, text/event-stream');
+    });
+
+    test('handshake POSTs occur in the order initialize → notifications/initialized → user request', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $methods = [];
+        $initResp = new Response(200, ['mcp-session-id' => 'sid', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp = new Response(202, [], '');
+        $reqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => []]));
+
+        $mockClient->shouldReceive('request')->times(3)
+            ->with('POST', '', Mockery::on(function ($opts) use (&$methods) {
+                $methods[] = $opts['json']['method'] ?? null;
+
+                return true;
+            }))
+            ->andReturn($initResp, $notifyResp, $reqResp);
+
+        $transporter->request('tools/list');
+
+        expect($methods)->toEqual(['initialize', 'notifications/initialized', 'tools/list']);
+    });
+
+    test('failure on notifications/initialized leaves transporter uninitialized so the next call retries', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $initResp = new Response(200, ['mcp-session-id' => 'sid', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp = new Response(202, [], '');
+        $reqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => ['ok' => true]]));
+
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andThrow(new TransferException('notify refused', 503));
+
+        expect(fn () => $transporter->request('first'))
+            ->toThrow(TransporterRequestException::class, 'HTTP error sending notifications/initialized');
+
+        // Next call should retry the full handshake.
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'second'))
+            ->andReturn($reqResp);
+
+        expect($transporter->request('second'))->toEqual(['ok' => true]);
     });
 });

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -5,6 +5,7 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
 use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
+use Redberry\MCPClient\Core\Mcp;
 use Redberry\MCPClient\Core\Transporters\HttpTransporter;
 
 afterEach(function () {
@@ -458,7 +459,7 @@ SSE;
 
         $transporter->request('ping');
 
-        expect($captured['params']['protocolVersion'])->toBe(\Redberry\MCPClient\Core\Mcp::PROTOCOL_VERSION)
+        expect($captured['params']['protocolVersion'])->toBe(Mcp::PROTOCOL_VERSION)
             ->and($captured['params']['capabilities'])->toBeInstanceOf(stdClass::class)
             ->and($captured['params']['clientInfo']['name'])->toBe('mcp-client-laravel')
             ->and($captured['params']['clientInfo']['version'])->toBeString()

--- a/tests/Transporter/StdioTransporterTest.php
+++ b/tests/Transporter/StdioTransporterTest.php
@@ -367,7 +367,7 @@ describe('StdioTransporter', function () {
             ->and($initialize['params']['protocolVersion'])->toBe(Mcp::PROTOCOL_VERSION)
             ->and($initialize['params']['clientInfo']['name'])->toBe('mcp-client-laravel')
             ->and($initialize['params']['clientInfo']['version'])->toBeString()
-            ->and($initialize['params']['clientInfo']['version'])->not->toBe('0.1.0')
+            ->and($initialize['params']['clientInfo']['version'])->not->toBe('')
             ->and($notification['method'])->toBe('notifications/initialized')
             ->and(array_key_exists('id', $notification))->toBeFalse();
     });

--- a/tests/Transporter/StdioTransporterTest.php
+++ b/tests/Transporter/StdioTransporterTest.php
@@ -2,6 +2,7 @@
 
 use Redberry\MCPClient\Core\Exceptions\ServerConfigurationException;
 use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
+use Redberry\MCPClient\Core\Mcp;
 use Redberry\MCPClient\Core\Transporters\StdioTransporter;
 use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
@@ -363,7 +364,7 @@ describe('StdioTransporter', function () {
 
         expect($initialize['method'])->toBe('initialize')
             ->and($initialize['id'])->toBe('init')
-            ->and($initialize['params']['protocolVersion'])->toBe(\Redberry\MCPClient\Core\Mcp::PROTOCOL_VERSION)
+            ->and($initialize['params']['protocolVersion'])->toBe(Mcp::PROTOCOL_VERSION)
             ->and($initialize['params']['clientInfo']['name'])->toBe('mcp-client-laravel')
             ->and($initialize['params']['clientInfo']['version'])->toBeString()
             ->and($initialize['params']['clientInfo']['version'])->not->toBe('0.1.0')

--- a/tests/Transporter/StdioTransporterTest.php
+++ b/tests/Transporter/StdioTransporterTest.php
@@ -334,6 +334,43 @@ describe('StdioTransporter', function () {
         expect($result)->toBe(['x' => 1]);
     });
 
+    it('sendInitializeRequests uses the shared protocol version and notifications/initialized method', function () {
+        $transporter = Mockery::mock(StdioTransporter::class, [['command' => ['echo', 'hi']]])->makePartial();
+        $transporter->shouldAllowMockingProtectedMethods();
+
+        $captured = [];
+
+        $inputStream = Mockery::mock(InputStream::class);
+        $inputStream->shouldReceive('write')
+            ->twice()
+            ->withArgs(function ($arg) use (&$captured) {
+                $captured[] = json_decode(trim($arg), true);
+
+                return true;
+            });
+        $inputStream->shouldReceive('close')->byDefault();
+
+        $ref = new ReflectionClass(StdioTransporter::class);
+        $streamProp = $ref->getProperty('inputStream');
+        $streamProp->setAccessible(true);
+        $streamProp->setValue($transporter, $inputStream);
+
+        $method = $ref->getMethod('sendInitializeRequests');
+        $method->setAccessible(true);
+        $method->invoke($transporter);
+
+        [$initialize, $notification] = $captured;
+
+        expect($initialize['method'])->toBe('initialize')
+            ->and($initialize['id'])->toBe('init')
+            ->and($initialize['params']['protocolVersion'])->toBe(\Redberry\MCPClient\Core\Mcp::PROTOCOL_VERSION)
+            ->and($initialize['params']['clientInfo']['name'])->toBe('mcp-client-laravel')
+            ->and($initialize['params']['clientInfo']['version'])->toBeString()
+            ->and($initialize['params']['clientInfo']['version'])->not->toBe('0.1.0')
+            ->and($notification['method'])->toBe('notifications/initialized')
+            ->and(array_key_exists('id', $notification))->toBeFalse();
+    });
+
     it('cleanup stops running process and unsets properties', function () {
         $transporter = Mockery::mock(StdioTransporter::class, [['command' => ['echo', 'run']]])->makePartial();
         $transporter->shouldAllowMockingProtectedMethods();


### PR DESCRIPTION
Our `initialize` handshake wasn't quite right. We were sending a bare `initialize` payload — no `protocolVersion`, no `capabilities`, no `clientInfo` — and never sending the `notifications/initialized` follow-up the spec asks for. Strict-spec MCP servers (the official TypeScript reference, Anthropic's own) reject this and refuse to talk to us further, so a lot of real-world servers were just unreachable.

This brings us in line with the [2025-03-26 lifecycle spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle):

- Initialize payload now carries `protocolVersion`, an empty `capabilities` object, and `clientInfo` with name and version.
- After initialize comes back, we POST `notifications/initialized` (no `id` — it's a notification) on the same session.
- If that notification POST fails, we leave the transporter uninitialized so the next request retries the whole handshake. There's a regression test for it.

A few related cleanups while I was in here:

- STDIO was sending the post-init notification with method `initialized`. Spec says `notifications/initialized`. Fixed.
- Pulled the protocol version and `clientInfo` resolution into a new `Redberry\MCPClient\Core\Mcp` class so both transporters share one source of truth. STDIO had `2024-11-05` hardcoded — both now report `2025-03-26`.
- `clientInfo.version` is now sourced from the installed composer package version instead of the hardcoded `0.1.0` STDIO was sending.

Closes ROADMAP P0.

## Test plan

- [x] `composer test` — all green, 5 new HTTP tests, 1 new STDIO test
- [x] `composer analyse` — PHPStan clean
- [x] `composer format` — Pint clean
- [x] Smoke against `@modelcontextprotocol/server-everything` over Streamable HTTP