### PR TITLE
chore: pin Pint config and align lint CI to PHP 8.4

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
 
       - name: Install Dependencies
         run: |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,4 +99,3 @@ P0 → P1 → P2 → P3 → P4 → P5 → P6. P0–P3 should each be its own PR;
 
 - Long-lived `GET /` SSE channel for unsolicited server→client notifications.
 - `Last-Event-ID` resumability.
-- The Pint config drift between fresh-clone and symlinked-workspace runs (separate investigation).

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,8 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "fully_qualified_strict_types": {
+            "import_symbols": true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The package had no `pint.json`, so both local and CI fell back to whatever the installed Pint version's `laravel` preset defaulted to that day. PHP version drift between local (8.4) and the lint workflow (8.3) compounded it. PR #35 tripped over this when CI rejected an inline fully-qualified class reference that local Pint was happy to leave alone.

- Commit `pint.json` with the `laravel` preset and the one rule that bit us pinned explicitly: `fully_qualified_strict_types` with `import_symbols: true`. Now both runs agree on this rule regardless of Pint's defaults shifting.
- Bump the lint workflow from PHP 8.3 to 8.4 to match local dev and the existing PHPStan workflow. PHP 8.3 stays covered by the test matrix in `run-tests.yml`.
- Remove the resolved Pint drift entry from ROADMAP "Out of scope".

## Test plan

- [x] `./vendor/bin/pint --test` passes locally with the new config
- [ ] CI lint workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)