### PR TITLE
fix: defensive error-message handling in SseStreamParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ All notable changes to `mcp-client-laravel` will be documented in this file.
 
 - Spec-correct `initialize` handshake on the HTTP transporter — payload now includes `protocolVersion`, `capabilities`, and `clientInfo`, and the required `notifications/initialized` notification is sent before the first user request. Strict-spec MCP servers (the official TS reference, Anthropic's servers) previously rejected the bare initialize.
 - STDIO transporter sent the post-initialize notification with method `initialized`; renamed to spec-correct `notifications/initialized`.
+- `SseStreamParser` no longer raises a PHP warning when a server returns a JSON-RPC error without a `message` field; falls back to `"Unknown JSON-RPC error"` while preserving the error `code`.

--- a/src/Core/Http/SseStreamParser.php
+++ b/src/Core/Http/SseStreamParser.php
@@ -124,8 +124,9 @@ class SseStreamParser
         }
 
         if (isset($decoded['error'])) {
+            $message = $decoded['error']['message'] ?? 'Unknown JSON-RPC error';
             throw new TransporterRequestException(
-                "JSON-RPC error: {$decoded['error']['message']}",
+                "JSON-RPC error: {$message}",
                 (int) ($decoded['error']['code'] ?? 0),
             );
         }

--- a/tests/Http/SseStreamParserTest.php
+++ b/tests/Http/SseStreamParserTest.php
@@ -107,6 +107,18 @@ SSE;
             ->toThrow(TransporterRequestException::class, 'JSON-RPC error: Method not found');
     });
 
+    test('falls back to a default message when the JSON-RPC error omits message', function () {
+        $sse = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32601}}\n\n";
+
+        try {
+            SseStreamParser::parse(Utils::streamFor($sse));
+            expect()->fail('Expected TransporterRequestException was not thrown.');
+        } catch (TransporterRequestException $e) {
+            expect($e->getMessage())->toBe('JSON-RPC error: Unknown JSON-RPC error')
+                ->and($e->getCode())->toBe(-32601);
+        }
+    });
+
     test('throws when the stream ends without any result', function () {
         $sse = <<<'SSE'
 data: {"jsonrpc":"2.0","method":"progress","params":{"pct":50}}


### PR DESCRIPTION
## Summary

- Mirror the `StdioTransporter` fallback in `SseStreamParser::dispatch()` so a JSON-RPC error event missing the `message` field no longer triggers a PHP warning. Falls back to `"Unknown JSON-RPC error"` while preserving the error `code` on the thrown `TransporterRequestException`.
- Adds a regression test covering the missing-`message` case.
- ROADMAP P1.

## Test plan

- [x] `bin/check` passes locally (Pint + PHPStan + Pest)
- [x] New test asserts the parser throws `TransporterRequestException` with `'JSON-RPC error: Unknown JSON-RPC error'` and code `-32601` when only `code` is sent
- [x] Existing SSE error-path test (`Method not found`) still passes