### PR TITLE
test: fix stdio startup-failure test on Windows CI

### DIFF
--- a/tests/Transporter/StdioTransporterTest.php
+++ b/tests/Transporter/StdioTransporterTest.php
@@ -38,8 +38,12 @@ describe('StdioTransporter', function () {
     });
 
     it('throws exception on startup failure', function () {
+        $command = PHP_OS_FAMILY === 'Windows'
+            ? ['cmd', '/c', 'exit', '1']
+            : ['false'];
+
         $transporter = new StdioTransporter([
-            'command' => ['false'],
+            'command' => $command,
         ]);
 
         $this->expectException(TransporterRequestException::class);


### PR DESCRIPTION
## Summary

- `it throws exception on startup failure` was spawning `['false']`, which doesn't exist on Windows. The process never exited before the 50 ms `startup_delay`, so `Process::isRunning()` was still `true`, control fell through to `waitForResponse()`, and the test failed with the timeout message instead of the asserted "Process failed to start" message.
- Now the command is OS-conditional: `['cmd', '/c', 'exit', '1']` on Windows, `['false']` elsewhere. Both branches exercise `StdioTransporter::handleStartupFailure()` exactly the same way.
- Test-only change. No production code touched.

Closes #39.

## Test plan

- [x] `bin/check` green locally on macOS (Pint + PHPStan + Pest, 95/95)
- [x] CI green on the Windows matrix (`P8.3 / P8.4` × `L11.* / L12.*` × `prefer-lowest / prefer-stable`)
- [x] CI still green on Linux/macOS matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)