### PR TITLE
feat: HTTP transporter recovers from server-side session loss (P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `mcp-client-laravel` will be documented in this file.
 - Optional `?callable $onEvent` parameter on `MCPClient::callTool()` and `MCPClient::readResource()` (and on the underlying `Transporter::request()` interface) for observing intermediate streamed events.
 - `HttpTransporter` constructor now accepts an optional Guzzle `ClientInterface` for dependency injection.
 - `read_timeout` config key on the HTTP transporter (default `60` seconds) — the maximum gap between SSE chunks before the parser aborts a wedged stream. The clock resets on every received chunk so long-running operations that stream progress events stay alive.
+- HTTP transporter now recovers from session loss: when a request to an active session returns HTTP 404 (the MCP 2025-03-26 signal for an expired/unknown session), the transporter clears the session, re-runs the `initialize` handshake, and retries the original request once. Configurable via the new `max_session_retries` key (default `1`, set `0` to disable).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ All file paths below are relative to the package root.
 
 ---
 
-## P1 — Defensive error-message handling in `SseStreamParser`
+## ~~P1 — Defensive error-message handling in `SseStreamParser`~~ ✅ Done
 
 **Problem.** `SseStreamParser::dispatch()` (`src/Core/Http/SseStreamParser.php`, lines 127–130) builds the exception message as `"JSON-RPC error: {$decoded['error']['message']}"`. If a server sends `{"error":{"code":-32601}}` without a `message` key, this emits a PHP warning and produces an empty-string error. STDIO already does this defensively in `StdioTransporter` (lines 239–240).
 
@@ -33,7 +33,7 @@ All file paths below are relative to the package root.
 
 ---
 
-## P2 — SSE read-timeout / wedge protection
+## ~~P2 — SSE read-timeout / wedge protection~~ ✅ Done
 
 **Problem.** `HttpTransporter` passes `timeout` to Guzzle, but that bounds connection/request setup, not body reads on a streamed response. A misbehaving server that keeps the connection open while sending nothing will park a queue worker indefinitely on `$stream->read()` in `SseStreamParser::parse()` (`src/Core/Http/SseStreamParser.php`, lines 41–42).
 
@@ -48,7 +48,7 @@ All file paths below are relative to the package root.
 
 ---
 
-## P3 — Session-loss recovery
+## ~~P3 — Session-loss recovery~~ ✅ Done
 
 **Problem.** `HttpTransporter::$initialized` and `$sessionId` are sticky on the instance. If the server tears down the session (per the MCP spec, this surfaces as HTTP 404 with a known error code, or a JSON-RPC error indicating "session not found"), we'll keep posting the stale `mcp-session-id` until the worker restarts. Realistic for queue workers and long-running daemons.
 

--- a/config/mcp-client.php
+++ b/config/mcp-client.php
@@ -9,6 +9,7 @@ return [
             'base_url' => 'https://api.githubcopilot.com/mcp',
             'timeout' => 30,
             'read_timeout' => 60, // seconds - max gap between SSE chunks before aborting; resets on each chunk. Set to null to disable. (default: 60)
+            'max_session_retries' => 1, // count - on HTTP 404 with an active session, clear session + re-initialize and retry up to this many times (default: 1, set 0 to disable)
             'token' => env('GITHUB_API_TOKEN', null),
             'id_type' => 'int', // 'string' or 'int' - controls JSON-RPC id type (default: 'int')
             'headers' => [

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -6,6 +6,7 @@ namespace Redberry\MCPClient\Core\Transporters;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface as GuzzleClient;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\GuzzleException;
 use JsonException;
 use Psr\Http\Message\ResponseInterface;
@@ -15,6 +16,8 @@ use Redberry\MCPClient\Core\Mcp;
 
 class HttpTransporter implements Transporter
 {
+    private const DEFAULT_MAX_SESSION_RETRIES = 1;
+
     private GuzzleClient $client;
 
     private ?string $sessionId = null;
@@ -90,24 +93,60 @@ class HttpTransporter implements Transporter
     public function request(string $action, array $params = [], ?callable $onEvent = null): array
     {
         $this->initializeSession();
-        $payload = $this->preparePayload($action, $params);
 
-        try {
-            $response = $this->client->request('POST', '', [
-                'json' => $payload,
-                'timeout' => $this->config['timeout'] ?? 30,
-                'stream' => true,
-                'headers' => $this->buildRequestHeaders(),
-            ]);
+        $maxRetries = (int) ($this->config['max_session_retries'] ?? self::DEFAULT_MAX_SESSION_RETRIES);
+        $attempt = 0;
 
-            return $this->parseResponse($response, $onEvent);
-        } catch (GuzzleException $e) {
-            throw new TransporterRequestException(
-                "HTTP error for {$action}: {$e->getMessage()}",
-                (int) $e->getCode(),
-                $e
-            );
+        while (true) {
+            try {
+                $response = $this->client->request('POST', '', [
+                    'json' => $this->preparePayload($action, $params),
+                    'timeout' => $this->config['timeout'] ?? 30,
+                    'stream' => true,
+                    'headers' => $this->buildRequestHeaders(),
+                ]);
+
+                return $this->parseResponse($response, $onEvent);
+            } catch (BadResponseException $e) {
+                if ($this->isSessionLoss($e) && $attempt < $maxRetries) {
+                    $attempt++;
+                    $this->reinitializeSession();
+
+                    continue;
+                }
+
+                throw new TransporterRequestException(
+                    "HTTP error for {$action}: {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e
+                );
+            } catch (GuzzleException $e) {
+                throw new TransporterRequestException(
+                    "HTTP error for {$action}: {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e
+                );
+            }
         }
+    }
+
+    /**
+     * Per the MCP 2025-03-26 Streamable HTTP spec, a server signals an
+     * expired or unknown session by returning HTTP 404 to a request that
+     * carries an `mcp-session-id` header. There is no standard JSON-RPC
+     * error code for session loss, so we detect it at the HTTP layer only.
+     */
+    private function isSessionLoss(BadResponseException $e): bool
+    {
+        return $this->sessionId !== null
+            && $e->getResponse()->getStatusCode() === 404;
+    }
+
+    private function reinitializeSession(): void
+    {
+        $this->sessionId = null;
+        $this->initialized = false;
+        $this->initializeSession();
     }
 
     /**

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -108,6 +108,10 @@ class HttpTransporter implements Transporter
                     'timeout' => $this->config['timeout'] ?? 30,
                     'stream' => true,
                     'headers' => $this->buildRequestHeaders(),
+                    // Force Guzzle to throw on 4xx/5xx even if an injected client
+                    // has `http_errors` disabled — otherwise a 404 would slip past
+                    // session-loss detection and surface as a parse error.
+                    'http_errors' => true,
                 ]);
 
                 return $this->parseResponse($response, $onEvent);

--- a/src/Core/Transporters/HttpTransporter.php
+++ b/src/Core/Transporters/HttpTransporter.php
@@ -86,8 +86,12 @@ class HttpTransporter implements Transporter
     }
 
     /**
+     * Both `BadResponseException` and other `GuzzleException`s raised by the
+     * underlying client are caught and wrapped in `TransporterRequestException`
+     * before leaving this method. `JsonException` may still escape from the
+     * SSE parsing path when an individual event payload fails to decode.
+     *
      * @throws TransporterRequestException
-     * @throws GuzzleException
      * @throws JsonException
      */
     public function request(string $action, array $params = [], ?callable $onEvent = null): array
@@ -138,6 +142,8 @@ class HttpTransporter implements Transporter
      */
     private function isSessionLoss(BadResponseException $e): bool
     {
+        // BadResponseException::getResponse() narrows the parent's nullable return
+        // to a non-null ResponseInterface, so it is always safe to dereference here.
         return $this->sessionId !== null
             && $e->getResponse()->getStatusCode() === 404;
     }

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
@@ -583,5 +585,158 @@ SSE;
             ->andReturn($reqResp);
 
         expect($transporter->request('second'))->toEqual(['ok' => true]);
+    });
+
+    test('HTTP 404 with active session re-initializes and retries the request once', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $initResp1 = new Response(200, ['mcp-session-id' => 'sid-1', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp1 = new Response(202, [], '');
+        $firstReqResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => ['n' => 1]]));
+
+        $sessionLost = new ClientException(
+            'Session not found',
+            new Request('POST', ''),
+            new Response(404, [], '')
+        );
+
+        $initResp2 = new Response(200, ['mcp-session-id' => 'sid-2', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp2 = new Response(202, [], '');
+        $retryResp = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => ['n' => 2]]));
+
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp1);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp1);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'first'
+                && ($opts['headers']['mcp-session-id'] ?? null) === 'sid-1'))
+            ->andReturn($firstReqResp);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'second'
+                && ($opts['headers']['mcp-session-id'] ?? null) === 'sid-1'))
+            ->andThrow($sessionLost);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp2);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp2);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'second'
+                && ($opts['headers']['mcp-session-id'] ?? null) === 'sid-2'))
+            ->andReturn($retryResp);
+
+        expect($transporter->request('first'))->toEqual(['n' => 1]);
+        expect($transporter->request('second'))->toEqual(['n' => 2]);
+    });
+
+    test('HTTP 404 followed by another 404 on retry surfaces as TransporterRequestException', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $initResp1 = new Response(200, ['mcp-session-id' => 'sid-1', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp1 = new Response(202, [], '');
+        $sessionLost1 = new ClientException(
+            'Session not found',
+            new Request('POST', ''),
+            new Response(404, [], '')
+        );
+        $initResp2 = new Response(200, ['mcp-session-id' => 'sid-2', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp2 = new Response(202, [], '');
+        $sessionLost2 = new ClientException(
+            'Session not found again',
+            new Request('POST', ''),
+            new Response(404, [], '')
+        );
+
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp1);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp1);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'doomed'))
+            ->andThrow($sessionLost1);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp2);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp2);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'doomed'))
+            ->andThrow($sessionLost2);
+
+        $this->expectException(TransporterRequestException::class);
+        $this->expectExceptionMessage('HTTP error for doomed: Session not found again');
+
+        $transporter->request('doomed');
+    });
+
+    test('max_session_retries=0 surfaces a 404 immediately without re-initializing', function () {
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter(['max_session_retries' => 0], $mockClient);
+
+        $initResp = new Response(200, ['mcp-session-id' => 'sid-1', 'Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp = new Response(202, [], '');
+        $sessionLost = new ClientException(
+            'Session not found',
+            new Request('POST', ''),
+            new Response(404, [], '')
+        );
+
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'noRetry'))
+            ->andThrow($sessionLost);
+        // No further initialize/request calls are expected — the assertion is implicit
+        // in Mockery's strict expectations, which will fail if the transporter retries.
+
+        $this->expectException(TransporterRequestException::class);
+        $this->expectExceptionMessage('HTTP error for noRetry: Session not found');
+
+        $transporter->request('noRetry');
+    });
+
+    test('404 from a sessionless server is not treated as session loss', function () {
+        // Some servers may complete `initialize` without returning an `mcp-session-id` header
+        // (sessionless mode). In that case a follow-up 404 is a real error, not session expiry,
+        // and must not trigger a retry.
+        $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter([], $mockClient);
+
+        $initRespNoSession = new Response(200, ['Content-Type' => 'application/json'], json_encode(['result' => []]));
+        $notifyResp = new Response(202, [], '');
+        $notFound = new ClientException(
+            'Not found',
+            new Request('POST', ''),
+            new Response(404, [], '')
+        );
+
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initRespNoSession);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp);
+        $mockClient->shouldReceive('request')->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'whatever'))
+            ->andThrow($notFound);
+        // No retry — the strict Mockery expectations will fail if a re-initialize is attempted.
+
+        $this->expectException(TransporterRequestException::class);
+        $this->expectExceptionMessage('HTTP error for whatever: Not found');
+
+        $transporter->request('whatever');
     });
 });


### PR DESCRIPTION
Closes ROADMAP P3.

## Summary

Per the MCP 2025-03-26 Streamable HTTP spec, a server signals an expired or unknown session by returning **HTTP 404** to a request carrying an `mcp-session-id` header. Until now, `HttpTransporter` would treat that 404 as a generic transport error and surface it to the caller — for queue workers and long-running daemons that meant "manual restart to recover." Not great.

This PR makes the transporter handle session loss transparently:

1. Catch `BadResponseException` ahead of the broader `GuzzleException` in `request()`.
2. If the response status is `404` **and** an `mcp-session-id` is currently set, treat as session loss: clear `$sessionId` + `$initialized`, re-run `initializeSession()`, retry the original request.
3. Cap retries via the new **`max_session_retries`** config key (default `1`, set `0` to disable).

### Spec note

The spec defines no JSON-RPC error code for session loss, so detection is HTTP-only. An inline doc comment on `isSessionLoss()` records that decision so a future maintainer doesn't try to bolt on a code-based heuristic.

### Roadmap housekeeping

The roadmap file was stale — only P0 was struck through, but P1 and P2 had already shipped (PRs #37 and #38). Marked them done in the same commit since the file was already open.

## Test plan

- [x] `bin/check` green locally (Pint + PHPStan + Pest, **99/99**, 4 new tests added)
- New tests:
  - 404 with active session → re-init + retry returns the result
  - 404 → retry also 404 → throws `TransporterRequestException`
  - `max_session_retries=0` → 404 surfaces immediately, no retry
  - 404 from a sessionless server (initialize returned no `mcp-session-id`) → not treated as session loss

## Out of scope

- JSON-RPC error-code-based session-loss detection (no standard code defined).
- Server-driven session rotation via response-header changes mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)