### PR TITLE
test: migrate HttpTransporter tests off reflection-based state setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to `mcp-client-laravel` will be documented in this file.
 
 - `composer.json` now explicitly requires `guzzlehttp/guzzle` and `psr/http-message`, which the HTTP transporter has always relied on transitively.
 - Both transporters now report `protocolVersion: 2025-03-26` and source `clientInfo.version` from the installed composer package version (was hardcoded `0.1.0` on STDIO). Shared in a new `Redberry\MCPClient\Core\Mcp` value class.
+- HTTP transporter tests now exercise the real `initialize` + `notifications/initialized` handshake via constructor injection instead of poking private state with reflection. No production behavior change.
 
 ### Fixed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,6 +63,8 @@ All file paths below are relative to the package root.
 
 ## ~~P4 — Cleanup: migrate reflection-based test setup~~ ✅ Done
 
+**Resolved in [PR #42](https://github.com/RedberryProducts/mcp-client-laravel/pull/42).** The reflection-based `createTransporterWithMockedSession()` helper was replaced with `setUpInitializedTransporter()`, which uses constructor injection and primes the `initialize` + `notifications/initialized` handshake via Mockery. The Problem/Task/Acceptance text below describes the pre-refactor state and references file locations that no longer exist.
+
 **Problem.** `createTransporterWithMockedSession()` in `tests/Transporter/HttpTransporterTest.php` (lines 16–38) uses `ReflectionClass` to poke private state. The new constructor-injection pattern from the same file (`client can be injected via constructor (no reflection needed)`, lines 288–302) is much cleaner.
 
 **Task.** Migrate every test that calls `createTransporterWithMockedSession()` to use constructor injection plus a real first call that primes the `initialize` exchange (you can add a tiny helper that returns `[$transporter, $mockClient]` and stubs the initialize POST). Delete the old helper. No behavior changes — just a refactor.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ All file paths below are relative to the package root.
 
 ---
 
-## P4 — Cleanup: migrate reflection-based test setup
+## ~~P4 — Cleanup: migrate reflection-based test setup~~ ✅ Done
 
 **Problem.** `createTransporterWithMockedSession()` in `tests/Transporter/HttpTransporterTest.php` (lines 16–38) uses `ReflectionClass` to poke private state. The new constructor-injection pattern from the same file (`client can be injected via constructor (no reflection needed)`, lines 288–302) is much cleaner.
 

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
+use Mockery\MockInterface;
 use Psr\Http\Message\StreamInterface;
 use Redberry\MCPClient\Core\Exceptions\TransporterRequestException;
 use Redberry\MCPClient\Core\Mcp;
@@ -16,27 +17,36 @@ afterEach(function () {
 });
 
 describe('HttpTransporter', function () {
-    // Helper function to set up the transporter with a mocked client and session
-    function createTransporterWithMockedSession($responseForInitialize = null)
+    /**
+     * Builds an HttpTransporter wired to a Mockery-mocked Guzzle client via
+     * constructor injection, and primes the initialize + notifications/initialized
+     * handshake so the first user request triggers a session id of 'test-session-id'.
+     *
+     * The handshake expectations are method-specific, so subsequent test
+     * expectations on the same mock won't be intercepted.
+     *
+     * @return array{0: HttpTransporter, 1: MockInterface}
+     */
+    function setUpInitializedTransporter(array $config = []): array
     {
-        $transporter = new HttpTransporter;
         $mockClient = Mockery::mock(Client::class);
+        $transporter = new HttpTransporter($config, $mockClient);
 
-        // Inject the mocked client
-        $ref = new ReflectionClass($transporter);
-        $prop = $ref->getProperty('client');
-        $prop->setAccessible(true);
-        $prop->setValue($transporter, $mockClient);
+        $initResp = new Response(
+            200,
+            ['mcp-session-id' => 'test-session-id', 'Content-Type' => 'application/json'],
+            json_encode(['result' => []])
+        );
+        $notifyResp = new Response(202, [], '');
 
-        // Set the sessionId to avoid uninitialized property errors
-        $sessionProp = $ref->getProperty('sessionId');
-        $sessionProp->setAccessible(true);
-        $sessionProp->setValue($transporter, 'test-session-id');
-
-        // Set initialized flag to true to skip initialization
-        $initializedProp = $ref->getProperty('initialized');
-        $initializedProp->setAccessible(true);
-        $initializedProp->setValue($transporter, true);
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'initialize'))
+            ->andReturn($initResp);
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
+            ->andReturn($notifyResp);
 
         return [$transporter, $mockClient];
     }
@@ -184,7 +194,7 @@ describe('HttpTransporter', function () {
     });
 
     test('successful request returns result field', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $response = new Response(200, [], json_encode(['result' => ['foo' => 'bar']]));
         $mockClient->shouldReceive('request')
@@ -203,7 +213,7 @@ describe('HttpTransporter', function () {
     });
 
     test('successful request returns full data when no result', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $response = new Response(200, [], json_encode(['foo' => 'bar']));
         $mockClient->shouldReceive('request')
@@ -222,7 +232,7 @@ describe('HttpTransporter', function () {
     });
 
     test('invalid JSON response throws TransporterRequestException', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $response = new Response(200, [], 'not-json');
         $mockClient->shouldReceive('request')
@@ -244,7 +254,7 @@ describe('HttpTransporter', function () {
     });
 
     test('JSON-RPC error throws TransporterRequestException with code', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $error = ['error' => ['message' => 'Something went wrong', 'code' => 400]];
         $response = new Response(200, [], json_encode($error));
@@ -268,7 +278,7 @@ describe('HttpTransporter', function () {
     });
 
     test('Guzzle exception is wrapped in TransporterRequestException', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $mockClient->shouldReceive('request')
             ->once()
@@ -315,7 +325,7 @@ describe('HttpTransporter', function () {
     });
 
     test('every request advertises both content types in Accept', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $response = new Response(200, [], json_encode(['result' => ['ok' => true]]));
         $mockClient->shouldReceive('request')
@@ -328,7 +338,7 @@ describe('HttpTransporter', function () {
     });
 
     test('SSE response is parsed and final result returned', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $sse = <<<'SSE'
 event: jsonrpc.message
@@ -348,7 +358,7 @@ SSE;
     });
 
     test('SSE Content-Type with charset suffix is recognized', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $sse = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n";
         $response = new Response(200, ['Content-Type' => 'text/event-stream; charset=utf-8'], Utils::streamFor($sse));
@@ -392,7 +402,7 @@ SSE;
     });
 
     test('onEvent callback receives every SSE event including the final result', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $sse = <<<'SSE'
 data: {"jsonrpc":"2.0","method":"progress","params":{"pct":50}}
@@ -431,7 +441,7 @@ SSE;
     });
 
     test('JSON response with scalar result returns the full envelope', function () {
-        [$transporter, $mockClient] = createTransporterWithMockedSession();
+        [$transporter, $mockClient] = setUpInitializedTransporter();
 
         $response = new Response(200, ['Content-Type' => 'application/json'], json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => 'plain-string']));
         $mockClient->shouldReceive('request')->once()->andReturn($response);


### PR DESCRIPTION
## Summary

Closes ROADMAP **P4**. Pure test refactor — no production code changes.

- Replaces `createTransporterWithMockedSession()` (which used `ReflectionClass` to poke private `$client`, `$sessionId`, and `$initialized`) with `setUpInitializedTransporter()`.
- The new helper builds the transporter via the existing constructor-injection seam and primes the `initialize` + `notifications/initialized` handshake with method-specific Mockery expectations, so each test now exercises the real handshake path before its own assertions.
- All 10 prior callers migrated; the old reflection helper is deleted.
- Reflection on private *methods* (`preparePayload`, `generateId`, `getClientBaseConfig`) is left in place — it's explicitly allowed by ROADMAP P4.

## Test plan

- [x] \`vendor/bin/pest tests/Transporter/HttpTransporterTest.php\` — 32 passed
- [x] \`bin/check\` (Pint → PHPStan → Pest) — 99 passed
- [x] \`grep -n "ReflectionClass" tests/Transporter/HttpTransporterTest.php\` — zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)