### PR TITLE
docs: prepare v2.0.0 release

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,8 +40,8 @@ The user-facing API lives in `src/MCPClient.php` and is intentionally small:
 | `connect(string $serverName)` | Picks a server config out of the map and instantiates the transporter via `TransporterFactory` | — |
 | `tools(): Collection` | `tools/list` JSON-RPC call | No |
 | `resources(): Collection` | `resources/list` JSON-RPC call | No |
-| `callTool(string $name, mixed $params, ?callable $onEvent): mixed` | `tools/call` JSON-RPC call, forwards `$onEvent` | Yes (when transport supports it) |
-| `readResource(string $uri, ?callable $onEvent): mixed` | `resources/read` JSON-RPC call, forwards `$onEvent` | Yes (when transport supports it) |
+| `callTool(string $name, mixed $params, ?callable $onEvent): array` | `tools/call` JSON-RPC call, forwards `$onEvent` | Yes (when transport supports it) |
+| `readResource(string $uri, ?callable $onEvent): array` | `resources/read` JSON-RPC call, forwards `$onEvent` | Yes (when transport supports it) |
 
 The contract for both `MCPClient` and the underlying `Transporter` lives in `src/Contracts/MCPClient.php` and `src/Core/Transporters/Transporter.php` — keep both interfaces narrow.
 
@@ -131,14 +131,15 @@ first request()
 - `text/event-stream` → `SseStreamParser::parse($body, $onEvent)`. The parser drives `$onEvent` and returns the result-bearing payload.
 - anything else → `json_decode` → return `$data['result']` if it's an array, else the whole envelope.
 
-JSON-RPC errors (`isset($data['error'])`) throw `TransporterRequestException` carrying the spec error code as the exception code.
+JSON-RPC errors (`isset($data['error'])`) throw `TransporterRequestException` carrying the spec error code as the exception code. The `message` field is read defensively (`$data['error']['message'] ?? 'Unknown JSON-RPC error'`) so spec-compliant servers that omit it don't trigger PHP warnings.
 
-### Known gaps (tracked in ROADMAP)
+### Session loss recovery
 
-- `initializeSession()` sends a bare `initialize` payload missing `protocolVersion` / `capabilities` / `clientInfo`, and never sends the follow-up `notifications/initialized`. Strict-spec servers reject this. (P0)
-- `random_int` request id generator can collide over a long-lived session. Should be an incrementing counter like STDIO. (P5)
-- No SSE read-timeout — a server that holds the connection open without sending parks the worker. (P2)
-- No session-loss recovery — a 404 from the server keeps replaying the stale session id. (P3)
+A request to an active session that returns HTTP `404` is the MCP spec signal that the session has expired or been evicted. `HttpTransporter` catches this case, clears its session id and `$initialized` flag, replays the `initialize` handshake, and retries the original request. The number of retries is bounded by `max_session_retries` (default `1`); set it to `0` to disable.
+
+### SSE read timeout
+
+The HTTP transport advertises `Accept: application/json, text/event-stream` on every request. When the server replies with an event stream, `SseStreamParser::parse()` enforces a maximum gap between chunks via `read_timeout` (default `60` seconds). The clock resets on every received chunk, so a tool that emits progress events stays alive indefinitely; only a wedged stream aborts.
 
 ---
 
@@ -158,11 +159,11 @@ first request()
     ├─ start():
     │   initializeProcess()           ◄── builds Process with InputStream
     │   $process->start()
-    │   usleep(startup_delay)         ◄── give server time to boot, default 50ms
+    │   usleep(startup_delay)               ◄── give server time to boot, default 100ms
     │   isRunning()? else handleStartupFailure()
     │   sendInitializeRequests():
     │     write {initialize} \n
-    │     write {initialized} \n      ◄── note: spec name is notifications/initialized
+    │     write {notifications/initialized} \n
     │
     └─ user request
         write {method, params, id: ++$requestId} \n
@@ -171,9 +172,8 @@ first request()
             buffer .= $process->getIncrementalOutput()
             for each newline-terminated line in buffer:
               json_decode; if id matches, return result (or throw on error)
-            usleep(poll_interval), default 10ms
-            timeout after $config['timeout']s
-            (default 3s — short on purpose)
+            usleep(poll_interval), default 20ms
+            timeout after request_timeout (default 30s)
     ▼
 __destruct() / close()
     inputStream->close()
@@ -181,15 +181,17 @@ __destruct() / close()
 ```
 
 - **Why lazy start.** Same reasoning as HTTP — constructing shouldn't fork a process.
-- **Why a startup delay.** Many MCP servers (especially `npx`-launched Node ones) take a moment to be ready to read from stdin. Without the delay, the first `initialize` write can race the server's readline loop. 50ms is a deliberately small default; users override via `startup_delay` ms.
+- **Why a startup delay.** Many MCP servers (especially `npx`-launched Node ones) take a moment to be ready to read from stdin. Without the delay, the first `initialize` write can race the server's readline loop. The default is `100`ms; users override via `startup_delay`.
+- **Why two timeouts.** `request_timeout` bounds a single `waitForResponse()` cycle; `process_timeout` is Symfony Process's whole-subprocess kill timer. Bundling them under one key meant queue workers issuing many tool calls over the same subprocess were killed mid-flight after one `timeout` worth of process life. They are now decoupled, with `process_timeout` defaulting to `null` (kill timer disabled).
+- **Why parent-env inheritance.** Forwarding only `PATH` silently broke `npx`/`node`, which need `HOME` to find npm caches and `NODE_OPTIONS`/`NPM_CONFIG_*` for many MCP servers. The transport now passes `null` to `Process` (clean inheritance) when no `env` is supplied, and merges user keys on top of `getenv()` when one is. `inherit_env: false` opts into a sealed env.
 - **Why polling instead of blocking reads.** Symfony Process's `getIncrementalOutput()` is non-blocking and drains both buffered stdout and any new bytes since the last call. We poll because the server can interleave notifications between requests, and we need to walk every line looking for our matching `id`.
 - **Why a per-instance counter for ids.** `++$this->requestId` is collision-free for the lifetime of the instance. No randomness, no `id_type` wobble — the cast to string is the only branch.
 
 ### Asymmetry with HTTP
 
-- `$onEvent` is currently **a no-op on STDIO** — the contract accepts it, but `waitForResponse()` only matches against the `id` and returns the result. We don't decode and surface intermediate notifications today. ROADMAP P6 tracks documenting this clearly in the README.
-- STDIO uses `protocolVersion: '2024-11-05'` while the HTTP target is `2025-03-26`. ROADMAP P0 promotes the constant to one shared place and aligns both.
-- STDIO hardcodes `clientInfo.version` to `'0.1.0'`. Should be sourced from `\Composer\InstalledVersions` (P0).
+`$onEvent` is **a no-op on STDIO**. The contract accepts the parameter so callers can pass it unconditionally, but `waitForResponse()` only matches against the JSON-RPC `id` and returns the matching result; intermediate notifications are not decoded or surfaced. The `Transporter::request()` docblock and the README both spell this out for callers.
+
+Both transports source `protocolVersion` from `Mcp::PROTOCOL_VERSION` and `clientInfo` from `Mcp::clientInfo()`, so version handling is centralised.
 
 ---
 
@@ -240,15 +242,11 @@ parse(StreamInterface $stream, ?callable $onEvent): array
 - If the message has a `result`, record it as the new "final."
 - Reset `current` to an empty event.
 
-Comment lines (`:`-prefixed) and `data: [DONE]` sentinels are ignored. Multi-line `data:` continuations are concatenated with `\n` before decoding.
+Comment lines (`:`-prefixed) and `data: [DONE]` sentinels are ignored. Multi-line `data:` continuations are concatenated with `\n` before decoding. Error events without a `message` field fall back to `'Unknown JSON-RPC error'` so spec-compliant servers that omit it do not trigger PHP warnings.
 
 ### Why a custom parser
 
 Guzzle doesn't ship an SSE decoder; pulling one as a dep just for this one use case isn't worth it. The class is ~140 lines and has explicit unit tests in `tests/Http/SseStreamParserTest.php`.
-
-### Known gap
-
-Error events with no `message` field emit an undefined-index warning today (P1 in ROADMAP). Defensive read: `$decoded['error']['message'] ?? 'Unknown JSON-RPC error'`.
 
 ---
 
@@ -260,12 +258,14 @@ Error events with no `message` field emit an undefined-index warning today (P1 i
 
 ```php
 'github' => [
-    'type'     => Transporters::HTTP,
-    'base_url' => 'https://api.githubcopilot.com/mcp',
-    'timeout'  => 30,                    // seconds; bounds connection setup, NOT body reads
-    'token'    => env('GITHUB_API_TOKEN'),
-    'id_type'  => 'int',                 // 'int' | 'string' — JSON-RPC id cast
-    'headers'  => [],                    // override Accept/Authorization if needed
+    'type'                => Transporters::HTTP,
+    'base_url'            => 'https://api.githubcopilot.com/mcp',
+    'token'               => env('GITHUB_API_TOKEN'),
+    'timeout'             => 30,           // seconds; connection timeout
+    'read_timeout'        => 60,           // seconds; max gap between SSE chunks (null disables)
+    'max_session_retries' => 1,            // retries after a session-loss 404 (0 disables)
+    'headers'             => [],           // merged into every request
+    'id_type'             => 'int',        // 'int' | 'string' — JSON-RPC id cast
 ],
 ```
 
@@ -273,15 +273,19 @@ Error events with no `message` field emit an undefined-index warning today (P1 i
 
 ```php
 'npx_mcp_server' => [
-    'type'          => Transporters::STDIO,
-    'command'       => ['npx', '-y', '@modelcontextprotocol/server-memory'],
-    'timeout'       => 30,               // seconds, applies to waitForResponse
-    'cwd'           => base_path(),
-    'env'           => [],               // PATH is auto-merged
-    'startup_delay' => 50,               // ms after process start
-    'poll_interval' => 10,               // ms between getIncrementalOutput() polls
+    'type'            => Transporters::STDIO,
+    'command'         => ['npx', '-y', '@modelcontextprotocol/server-memory'],
+    'cwd'             => base_path(),
+    'env'             => null,             // user keys merged on top of parent env
+    'inherit_env'     => true,             // false → forward only the `env` keys
+    'request_timeout' => 30,               // seconds, applies to waitForResponse
+    'process_timeout' => null,             // seconds, Symfony Process kill timer; null disables
+    'startup_delay'   => 100,              // ms after process start
+    'poll_interval'   => 20,               // ms between getIncrementalOutput() polls
 ],
 ```
+
+The legacy `timeout` key on STDIO falls through to `request_timeout` when only that is set, so 1.x configs keep working without reaching for the kill timer.
 
 The factory dispatches on `type`; everything else is transport-specific and only the relevant transporter inspects its keys.
 
@@ -294,7 +298,7 @@ Two exceptions, both extending `\Exception`:
 - `Redberry\MCPClient\Core\Exceptions\TransporterRequestException` — every transport-layer failure: HTTP errors, JSON-RPC errors, malformed responses, timeouts, eventual session loss. Code preserves the spec JSON-RPC error code where applicable.
 - `Redberry\MCPClient\Core\Exceptions\ServerConfigurationException` — invalid config shape detected at construction (currently only thrown by `StdioTransporter` for missing `command`).
 
-`MCPClient::ensureConfigurationValidity()` throws a vanilla `\RuntimeException` for unknown server names — that one's a programmer error, not a runtime IO problem.
+`MCPClient::connect()` throws a vanilla `\RuntimeException` for unknown server names, and `callTool()` / `readResource()` throw the same when called without a prior `connect()` — both are programmer errors, not runtime IO problems.
 
 Callers should catch `TransporterRequestException` for IO failures. They should never need to catch raw `GuzzleException` or `JsonException` — those are wrapped at the transport boundary.
 
@@ -305,7 +309,7 @@ Callers should catch `TransporterRequestException` for IO failures. They should 
 - **Pest** with Orchestra Testbench (`tests/TestCase.php`).
 - **No real network or subprocesses.** HTTP transporter tests inject a Guzzle `Client` wrapping `MockHandler`. SSE parser tests feed a `StreamInterface` mock. STDIO transporter tests use stub commands or fixtures, not real `npx`.
 - **Architecture rule.** `tests/ArchTest.php` forbids `dd`, `dump`, `ray` in source files.
-- **Constructor injection over reflection.** `HttpTransporter` accepts an optional Guzzle client specifically so tests don't need `ReflectionClass`. New tests should follow that pattern (legacy reflection-based helpers are tracked for removal in ROADMAP P4).
+- **Constructor injection over reflection.** `HttpTransporter` accepts an optional Guzzle client specifically so tests don't need `ReflectionClass`. New tests should follow that pattern.
 - **Real-shape fixtures** live in `tests/Datasets/` (e.g. `GithubResponseExample.php`).
 
 See [`.claude/rules/testing.md`](.claude/rules/testing.md) for the full testing rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `mcp-client-laravel` will be documented in this file.
 
 ## Unreleased
 
+This release contains breaking changes. See [UPGRADE.md](UPGRADE.md) for the `1.x → 2.x` migration guide.
+
 ### Added
 
 - Laravel 13 and PHP 8.5 support. `composer.json` now allows `illuminate/contracts: ^10.0||^11.0||^12.0||^13.0`, `php: ^8.3||^8.4||^8.5`, and `orchestra/testbench: ^8.22||^9.0||^10.0||^11.0`. Laravel 10 remains installable in package constraints during user transitions but is no longer covered by CI. The CI test matrix now runs PHP 8.3/8.4/8.5 against Laravel 11/12/13 (each with its matching Testbench major), `prefer-lowest` and `prefer-stable`. PHPStan, Pint, Pest, and pest-plugin-laravel constraints widened to track the latest majors (Pest 4, pest-plugin-laravel 4, Larastan 3-only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `mcp-client-laravel` will be documented in this file.
 
-## Unreleased
+## v2.0.0 - 2026-05-05
 
 This release contains breaking changes. See [UPGRADE.md](UPGRADE.md) for the `1.x → 2.x` migration guide.
 

--- a/README.md
+++ b/README.md
@@ -5,42 +5,17 @@
 [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/redberryproducts/mcp-client-laravel/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/redberryproducts/mcp-client-laravel/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/redberry/mcp-client-laravel.svg?style=flat-square)](https://packagist.org/packages/redberry/mcp-client-laravel)
 
-<p align="center">
-  <strong>Laravel-native client for Model Context Protocol (MCP) servers</strong><br>
-  Built and maintained by <a href="[https://redberry.international](https://redberry.international/?utm_source=github&utm_medium=github_mcp_readme&utm_campaign=AI+service+campaign)">Redberry</a>, a Diamond-tier official Laravel partner.
-</p>
-
-<p align="center">
-  <a href="[https://redberry.international/ai-agent-development/](https://redberry.international/ai-agent-development/?utm_source=github&utm_medium=github_mcp_readme&utm_campaign=AI+service+campaign)">AI PoC Sprint</a>
-</p>
-
----
-
-## 🚀 What is This?
-
-This package provides a Laravel-native client for interacting with **Model Context Protocol (MCP)** servers — enabling your Laravel application to communicate with external tools, structured resources, and memory services in a standardized way.
-
-It is **framework-agnostic** and can be used in any Laravel application. Agent frameworks like [LarAgent](https://github.com/MaestroError/LarAgent) use this package internally to enable tool use, memory management, and reasoning across distributed contexts.
-
-Use it to:
-
-- Connect to any MCP-compliant server over HTTP or STDIO
-- Discover and call tools defined on MCP servers
-- Access structured memory and contextual resources
-- Extend your Laravel apps with AI-ready interfaces to external agents or toolchains
-
-> 🚀 Looking to build an AI agent in Laravel? [Talk to us]([https://redberry.international/ai-agent-development/](https://redberry.international/ai-agent-development/?utm_source=github&utm_medium=github_mcp_readme&utm_campaign=AI+service+campaign)) about our 5-week PoC sprint — from idea to working prototype.
+A Laravel client for the [Model Context Protocol](https://modelcontextprotocol.io/). It speaks JSON-RPC 2.0 over both [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) (`2025-03-26`) and STDIO, and exposes a single facade for listing and calling tools and reading resources. The HTTP transport content-negotiates with the server on every request, so you receive the final result whether the server replies with one JSON object or a stream of server-sent events.
 
 ## Installation
-_Note that while project is running with `php artisan serve` **STDIO** transporter doesn't work_
 
-You can install the package via composer:
+Install the package via Composer:
 
 ```bash
 composer require redberry/mcp-client-laravel
 ```
 
-After installation, publish the configuration file:
+Then publish the configuration file:
 
 ```bash
 php artisan vendor:publish --tag="mcp-client-config"
@@ -50,168 +25,149 @@ This will create a `config/mcp-client.php` file in your application.
 
 ## Configuration
 
-The published configuration file contains settings for your MCP servers. Here's an example configuration:
+The `mcp-client.servers` array maps a server name to its connection details. Each server uses one of two transports — `HTTP` for remote servers, `STDIO` for local subprocesses:
 
 ```php
+use Redberry\MCPClient\Enums\Transporters;
+
 return [
     'servers' => [
         'github' => [
-            'type' => \Redberry\MCPClient\Enums\Transporters::HTTP,
+            'type'     => Transporters::HTTP,
             'base_url' => 'https://api.githubcopilot.com/mcp',
-            'timeout' => 30,
-            'token' => env('GITHUB_API_TOKEN', null),
+            'token'    => env('GITHUB_API_TOKEN'),
+            'timeout'  => 30,
         ],
-        'npx_mcp_server' => [
-            'type' => \Redberry\MCPClient\Enums\Transporters::STDIO,
-            'command' => [
-                'npx',
-                '-y',
-                '@modelcontextprotocol/server-memory',
-            ],
-            'request_timeout' => 30,
-            'process_timeout' => null,
-            'cwd' => base_path(),
+
+        'memory' => [
+            'type'    => Transporters::STDIO,
+            'command' => ['npx', '-y', '@modelcontextprotocol/server-memory'],
+            'cwd'     => base_path(),
         ],
     ],
 ];
 ```
 
-### Configuration Options
+### HTTP Transport
 
-#### HTTP Transporter
+The HTTP transport implements MCP's [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). On the first request, it performs the `initialize` handshake and captures the `mcp-session-id` for the rest of the session. If the server later signals that the session has expired with an HTTP `404`, the client clears its session, re-handshakes, and retries the call once.
 
--   `type`: Set to `Redberry\MCPClient\Enums\Transporters::HTTP` for HTTP connections
--   `base_url`: The base URL of the MCP server
--   `timeout`: Request timeout in seconds
--   `token`: Authentication token (if required)
+| Key | Default | Description |
+| --- | --- | --- |
+| `base_url` | — | The MCP endpoint URL. |
+| `token` | `null` | Bearer token; sent as `Authorization: Bearer {token}` when present. |
+| `timeout` | `30` | Connection timeout in seconds. |
+| `read_timeout` | `60` | Maximum gap between SSE chunks before the parser aborts a wedged stream. The clock resets on every chunk. Set to `null` to disable. |
+| `max_session_retries` | `1` | Automatic retries after a session-loss `404`. Set to `0` to disable. |
+| `headers` | `[]` | Additional headers merged into every request. |
+| `id_type` | `'int'` | `'int'` or `'string'`; controls how JSON-RPC ids are cast. |
 
-The HTTP transporter implements MCP's [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). Each request advertises `Accept: application/json, text/event-stream`, and the server decides — per call — whether to respond with a single JSON object or an SSE stream of JSON-RPC messages. The client handles both transparently: you always receive the final `result`, regardless of how the server chose to deliver it.
+### STDIO Transport
 
-#### STDIO Transporter
+The STDIO transport launches the configured command as a subprocess and exchanges newline-delimited JSON-RPC over its standard streams. The subprocess starts lazily on the first call and is reused for every subsequent request.
 
--   `type`: Set to `Redberry\MCPClient\Enums\Transporters::STDIO` for STDIO connections
--   `command`: Array of command parts to execute the MCP server
--   `request_timeout`: Per-call wait timeout in seconds for a JSON-RPC response (default: `30`). Falls back to the legacy `timeout` key when only that is set.
--   `process_timeout`: Symfony Process kill timer in seconds; `null` disables it (default: `null`). Set only if you need a hard upper bound on the entire subprocess lifetime — long-lived sessions (e.g. queue workers calling tools across many jobs) typically want it disabled.
--   `cwd`: Current working directory for the command
--   `env`: Environment variables to forward to the subprocess. Merged on top of the parent env (`PATH`, `HOME`, etc.) so `npx` / `node` keep working out of the box. Pass `inherit_env: false` for a sealed env containing only the keys listed here.
--   `inherit_env`: When `false`, the subprocess receives only the keys in `env`. Default: `true`.
--   `startup_delay`: Milliseconds to wait after `process->start()` before sending the initialize handshake (default: `100`). Increase if a cold-start `npx -y …` is still booting when the handshake fires.
--   `poll_interval`: Milliseconds between reads of the subprocess output buffer while waiting for a response (default: `20`).
+| Key | Default | Description |
+| --- | --- | --- |
+| `command` | — | Array of command parts to launch. |
+| `cwd` | `null` | Working directory for the subprocess. |
+| `env` | `null` | Environment variables, merged on top of the parent environment. |
+| `inherit_env` | `true` | When `false`, the subprocess receives only the keys listed in `env`. |
+| `request_timeout` | `30` | Per-call wait for a JSON-RPC response, in seconds. Falls back to the legacy `timeout` key when only that is set. |
+| `process_timeout` | `null` | Symfony Process kill timer, in seconds. Set this only if you need a hard upper bound on the subprocess lifetime. |
+| `startup_delay` | `100` | Milliseconds to wait after `Process::start()` before sending the `initialize` handshake. Increase if a cold-start `npx -y …` is still booting when the handshake fires. |
+| `poll_interval` | `20` | Milliseconds between reads of the subprocess output buffer. |
 
-## Usage
+> **Note.** The STDIO transport does not work under `php artisan serve`. The built-in PHP development server tears down its worker between requests, which kills the long-running subprocess. Run your application via Octane, a queue worker, Sail, or Valet to use STDIO servers.
 
-### Basic Usage
+## Connecting to a Server
+
+Resolve the client and call `connect` with a server name from your configuration:
 
 ```php
 use Redberry\MCPClient\Facades\MCPClient;
 
-// Connect to a specific MCP server defined in your config
-$client = MCPClient::connect('github');
-
-// Get available tools from the MCP server
-$tools = $client->tools();
-
-// Get available resources from the MCP server
-$resources = $client->resources();
+$github = MCPClient::connect('github');
 ```
 
-### Using Dependency Injection
+The container binds the client as a singleton and aliases the `Redberry\MCPClient\Contracts\MCPClient` interface to it, so the facade and dependency injection on the contract resolve the same instance:
 
 ```php
-use Redberry\MCPClient\MCPClient;
+use Redberry\MCPClient\Contracts\MCPClient;
 
-class MyService
+class GithubToolService
 {
-    public function __construct(private MCPClient $mcpClient)
-    {
-    }
+    public function __construct(private MCPClient $client) {}
 
-    public function getToolsFromGithub()
+    public function tools()
     {
-        return $this->mcpClient->connect('github')->tools();
+        return $this->client->connect('github')->tools();
     }
 }
 ```
 
-### Working with Collections
-
-The `tools()` and `resources()` methods return a `Collection` object that provides helpful methods for working with the results:
+`connect` returns a per-server clone of the client, so you may hold handles to multiple servers at once without one routing through another:
 
 ```php
-// Get all tools as an array
-$allTools = $client->tools()->all();
+$github = MCPClient::connect('github');
+$memory = MCPClient::connect('memory');
 
-// Get only specific tools by name
-$specificTools = $client->tools()->only('tool1', 'tool2');
-
-// Exclude specific tools
-$filteredTools = $client->tools()->except('tool3');
-
-// Map over tools
-$mappedTools = $client->tools()->map(function ($tool) {
-    return $tool['name'];
-});
+$github->tools();
+$memory->tools();
 ```
 
-> `only()` and `except()` filter on `name` for tools and on `uri` for resources — collections returned by `tools()` and `resources()` know which key to match on.
+Repeated `connect` calls for the same server reuse a cached transporter, so the `initialize` handshake is paid once per server per root instance.
 
-### Call tools
+## Listing Tools and Resources
 
-The `callTool` method is used to execute specific tool. Here is the signature:
+The `tools` and `resources` methods return a `Collection` of associative arrays:
 
 ```php
-public function callTool(string $toolName, mixed $params = [], ?callable $onEvent = null): mixed;
+$tools = $github->tools();
+
+$tools->all();                          // raw array
+$tools->only('search', 'create_issue'); // by name
+$tools->except('delete_repository');    // by name
+$tools->map(fn ($tool) => $tool['name']);
 ```
 
-Example:
+The same `Collection` wraps both lists, but `only` and `except` know which key to filter on — `name` for tools and `uri` for resources.
+
+## Calling a Tool
+
+Pass the tool name and an associative array of arguments. The method returns the decoded JSON-RPC `result` array:
 
 ```php
-$result = $client->callTool('create_entities', [
-    'entities' => [
-        [
-            'name' => 'John Doe',
-            'entityType' => 'PERSON',
-            'observations' => ['Test observation 1', 'Test observation 2'],
-        ]
-    ],
+$result = $github->callTool('create_issue', [
+    'owner' => 'laravel',
+    'repo'  => 'framework',
+    'title' => 'Documentation feedback',
+    'body'  => '…',
 ]);
 ```
 
-#### Observing streamed events
+## Reading a Resource
 
-When the server responds with an SSE stream, you can pass an `$onEvent` callback to observe every decoded JSON-RPC message — progress notifications, partial results, log entries, and the final result-bearing message — as each one arrives. The call still blocks until the final `result` is returned.
+Pass the URI of the resource. The method returns the decoded JSON-RPC `result` array:
 
 ```php
-$result = $client->callTool('long_running_tool', $args, function (array $event) {
-    // $event is a decoded JSON-RPC message: notification, progress, or final result
-    logger()->debug('mcp event', $event);
+$result = $github->readResource('file:///project/src/main.rs');
+```
+
+## Streaming Events
+
+Both `callTool` and `readResource` accept an optional callback as the last argument. When the server replies with an SSE stream, the callback is invoked for every decoded JSON-RPC message — progress notifications, log entries, partial results, and the final result-bearing one — as each arrives. The call still blocks until the final result is returned:
+
+```php
+$result = $github->callTool('long_running_task', $args, function (array $event) {
+    Log::info('mcp event', $event);
 });
 ```
 
-The callback is invoked zero times if the server returns a single JSON response, so it is safe to pass unconditionally.
+The callback is invoked zero times when the server replies with a single JSON object, so it is safe to pass unconditionally. Streaming is an HTTP-only concept; the callback is a no-op under the STDIO transport.
 
-> **Transport note.** Streaming events are an HTTP-only concept (specifically, MCP's Streamable HTTP `text/event-stream` responses). When the active server is configured with `type: stdio`, or when an HTTP server replies with a single JSON message, `$onEvent` fires zero times. You do not need to branch on the active transport — passing `$onEvent` is always safe; it is simply a no-op when the server isn't streaming.
+## Custom Transports
 
-### Read Resources
-
-The `readResource` method is used to retrieve the resource by the `uri`. It accepts the same optional `$onEvent` callback as `callTool`.
-
-```php
-public function readResource(string $uri, ?callable $onEvent = null): mixed;
-```
-
-Example:
-
-```php
-$result = $client->readResource("file:///project/src/main.rs");
-```
-
-## Advanced Usage
-
-### Creating Custom Transporters
-
-If you need to create a custom transporter, you can extend the `Transporter` interface and implement your own transport mechanism. Then register it in the `TransporterFactory`.
+The package ships with HTTP and STDIO transports, and the IO seam is a single interface — `Redberry\MCPClient\Core\Transporters\Transporter`. To add another, implement the interface, register a case on `Redberry\MCPClient\Enums\Transporters`, and add a `match` arm to `TransporterFactory::make`. See [`ARCHITECTURE.md`](ARCHITECTURE.md) and [`.claude/rules/transporters.md`](.claude/rules/transporters.md) for the full contract.
 
 ## Testing
 
@@ -219,27 +175,29 @@ If you need to create a custom transporter, you can extend the `Transporter` int
 composer test
 ```
 
-## Changelog
-
-Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
-
 ## Upgrading
 
-Upgrading from `1.x` to `2.x`? See [UPGRADE.md](UPGRADE.md) for breaking changes and a step-by-step migration guide.
+Upgrading from `1.x` to `2.x`? See [`UPGRADE.md`](UPGRADE.md) for the migration guide.
+
+## Changelog
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the list of changes.
 
 ## Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines.
 
 ## Security Vulnerabilities
 
-Please review [our security policy](../../security/policy) on how to report security vulnerabilities.
+Please review [our security policy](../../security/policy) before reporting a vulnerability.
 
 ## Credits
 
--   [Nika Jorjoliani](https://github.com/nikajorjika)
--   [All Contributors](../../contributors)
+- [Nika Jorjoliani](https://github.com/nikajorjika)
+- [All Contributors](../../contributors)
+
+Built and maintained by [Redberry](https://redberry.international/?utm_source=github&utm_medium=github_mcp_readme&utm_campaign=AI+service+campaign), a Diamond-tier Laravel partner. We also run a [5-week AI agent PoC sprint](https://redberry.international/ai-agent-development/?utm_source=github&utm_medium=github_mcp_readme&utm_campaign=AI+service+campaign) for teams exploring agentic features in Laravel.
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+The MIT License (MIT). Please see [`LICENSE.md`](LICENSE.md) for more information.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ composer test
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
+## Upgrading
+
+Upgrading from `1.x` to `2.x`? See [UPGRADE.md](UPGRADE.md) for breaking changes and a step-by-step migration guide.
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Follow-up work tracked after [PR #33](https://github.com/RedberryProducts/mcp-client-laravel/pull/33) (Streamable HTTP transport). All P0–P7 items have shipped.
+Follow-up work tracked after [PR #33](https://github.com/RedberryProducts/mcp-client-laravel/pull/33) (Streamable HTTP transport). All P0–P10 items have shipped, cut as `v2.0.0`.
 
 ## Completed
 
@@ -12,6 +12,9 @@ Follow-up work tracked after [PR #33](https://github.com/RedberryProducts/mcp-cl
 - ~~**P5** — Cleanup: switch HTTP request IDs to an incrementing counter~~ — [PR #43](https://github.com/RedberryProducts/mcp-client-laravel/pull/43)
 - ~~**P6** — Document `$onEvent` is a no-op on STDIO~~ — [PR #43](https://github.com/RedberryProducts/mcp-client-laravel/pull/43)
 - ~~**P7** — `MCPClient` surface: singleton DI, contract alias, immutable `connect`, missing guards~~ — [#48](https://github.com/RedberryProducts/mcp-client-laravel/issues/48)
+- ~~**P8** — STDIO robustness: split `request_timeout` / `process_timeout`, parent-env inheritance, diagnosable startup failures~~ — [PR #51](https://github.com/RedberryProducts/mcp-client-laravel/pull/51)
+- ~~**P9** — Defensive `error.message` handling on the HTTP JSON path (mirror of P1 for `parseResponse()`)~~ — [PR #49](https://github.com/RedberryProducts/mcp-client-laravel/pull/49)
+- ~~**P10** — `Collection::only()` / `except()` filter on a configurable key (`name` for tools, `uri` for resources)~~ — [PR #50](https://github.com/RedberryProducts/mcp-client-laravel/pull/50)
 
 The original problem statements, tasks, and acceptance criteria for each item are preserved in this file's git history.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,220 @@
+# Upgrade Guide
+
+## Upgrading from `1.x` to `2.x`
+
+Version `2.0` lands the spec-correct Streamable HTTP transport, a singleton service binding, an immutable `connect()`, and a clean split between the STDIO request timeout and the subprocess kill timer. Most users will only need to read sections **1**, **5**, and **6**.
+
+If you maintain a third-party transport or a class that implements `Contracts\MCPClient`, also read section **8**.
+
+### Quick scan
+
+| Likely affects you if you… | See |
+| --- | --- |
+| Hold two `connect()` results to two different servers in the same scope | [1. `connect()` is now immutable](#1-connect-is-now-immutable) |
+| Mutate `config('mcp-client.servers')` at runtime | [2. `MCPClient` is bound as a singleton](#2-mcpclient-is-bound-as-a-singleton) |
+| Type-hint `Contracts\MCPClient` in DI | [3. The contract is now resolvable from DI](#3-the-contract-is-now-resolvable-from-di) |
+| Set `timeout` on a STDIO server config | [4. STDIO `timeout` no longer kills the subprocess](#4-stdio-timeout-no-longer-kills-the-subprocess) |
+| Rely on a sealed environment for a STDIO subprocess | [5. STDIO `env` now inherits the parent env](#5-stdio-env-now-inherits-the-parent-env) |
+| Run long-idle SSE streams through the HTTP transport | [6. HTTP transport defaults to a 60s SSE read timeout](#6-http-transport-defaults-to-a-60s-sse-read-timeout) |
+| Treat `callTool()` / `readResource()` results as scalars | [7. `callTool()` / `readResource()` return `array`](#7-calltool--readresource-return-array) |
+| Implement a custom `Transporter` or `Contracts\MCPClient` | [8. Interface signatures tightened](#8-interface-signatures-tightened) |
+
+---
+
+### 1. `connect()` is now immutable
+
+**What changed.** `MCPClient::connect($server)` used to mutate the root client in place and return `$this`. It now returns a *clone* configured for the requested server; the root client is unchanged. Repeated `connect($same)` reuses a cached `Transporter` on the root, so the `initialize` handshake is paid once per server per root instance.
+
+**Why.** The previous behavior silently broke any code holding two handles to two servers — both handles routed through whichever server was connected to last.
+
+**Action.** If you chain (`MCPClient::connect('github')->tools()`) you are already correct. If you hold the result, capture it explicitly per server:
+
+```php
+// Before — the second connect() rerouted $github to the npx server.
+$github = MCPClient::connect('github');
+$npx    = MCPClient::connect('npx_mcp_server');
+
+$github->tools(); // accidentally hit npx_mcp_server in 1.x
+
+// After — each handle is isolated.
+$github = MCPClient::connect('github');
+$npx    = MCPClient::connect('npx_mcp_server');
+
+$github->tools(); // correct, hits github
+```
+
+If a class member held the connected client, capture it once and reuse:
+
+```php
+class MyService
+{
+    public function __construct(private MCPClient $mcpClient)
+    {
+        $this->mcpClient = $mcpClient->connect('github');
+    }
+}
+```
+
+---
+
+### 2. `MCPClient` is bound as a singleton
+
+**What changed.** `MCPClientServiceProvider` now binds `MCPClient` with `singleton()` instead of `bind()`. Every resolve from the container — facade, constructor injection, `app(MCPClient::class)` — returns the same instance. Server configuration is captured at first resolve.
+
+**Action.** If you mutate `config('mcp-client.servers')` after the first resolve and need the new config to take effect, force a re-resolve:
+
+```php
+config()->set('mcp-client.servers.github.token', $newToken);
+
+app()->forgetInstance(\Redberry\MCPClient\MCPClient::class);
+```
+
+Most apps will not need this — config is normally fixed for the request.
+
+---
+
+### 3. The contract is now resolvable from DI
+
+**What changed.** `Redberry\MCPClient\Contracts\MCPClient` is now aliased to the concrete singleton. Type-hinting the contract used to throw an unresolvable container error; it now resolves to the same singleton as the concrete class.
+
+**Action.** None required. If you previously worked around this by type-hinting the concrete `MCPClient`, you can switch to the contract for cleaner DI:
+
+```php
+use Redberry\MCPClient\Contracts\MCPClient;
+
+public function __construct(private MCPClient $client) {}
+```
+
+---
+
+### 4. STDIO `timeout` no longer kills the subprocess
+
+**What changed.** The single `timeout` config key used to control both the per-request wait *and* Symfony Process's kill timer. They are now separate keys:
+
+- `request_timeout` (default `30`s) — per-call wait inside `waitForResponse()`.
+- `process_timeout` (default `null`, kill timer disabled) — Symfony Process's 5th constructor argument.
+
+The legacy `timeout` key still falls back to `request_timeout` when only it is set. It no longer doubles as a process kill timer.
+
+**Why.** With the old behavior, queue workers issuing many tool calls over the same STDIO subprocess were killed mid-flight after `timeout` seconds of process life — every call after that failed.
+
+**Action.** Most users want the new behavior (long-lived subprocess, bounded per-request wait). If you genuinely want the old hard-kill behavior, set both keys:
+
+```php
+// Before
+'timeout' => 30,
+
+// After (long-lived subprocess, 30s per request — recommended)
+'request_timeout' => 30,
+
+// After (preserve 1.x behavior — process killed at 30s)
+'request_timeout' => 30,
+'process_timeout' => 30,
+```
+
+Default `request_timeout` was also raised from `3` to `30` so the README's `npx -y @modelcontextprotocol/server-memory` example completes its first-run cold start out of the box.
+
+---
+
+### 5. STDIO `env` now inherits the parent env
+
+**What changed.** The STDIO transport used to forward only `PATH` from the parent process — every other env var was scrubbed. It now passes `null` to Symfony Process when no `env` is supplied (full parent inheritance), and merges user `env` on top of `getenv()` when one is supplied.
+
+**Why.** `npx`, `node`, and most MCP servers need `HOME` (npm cache, npmrc), often `LANG`, `NODE_OPTIONS`, `NPM_CONFIG_*`. The 1.x behavior broke these silently.
+
+**Action.** No action required for typical use — your subprocess will usually now have *more* env access, not less. If you depend on a sealed environment (hermetic execution, secret scrubbing), opt in explicitly:
+
+```php
+'npx_mcp_server' => [
+    // …
+    'env' => ['NODE_OPTIONS' => '--max-old-space-size=512'],
+    'inherit_env' => false, // sealed: only the keys in `env` are forwarded
+],
+```
+
+---
+
+### 6. HTTP transport defaults to a 60s SSE read timeout
+
+**What changed.** `HttpTransporter` now enforces a maximum gap between SSE chunks via the new `read_timeout` config key (default `60` seconds). The clock resets on every received chunk, so a tool that emits progress events every few seconds stays alive indefinitely.
+
+**Action.** If you call tools that legitimately go silent for more than 60s mid-stream, raise or disable it:
+
+```php
+'github' => [
+    // …
+    'read_timeout' => 120,  // longer gap allowed
+    // or
+    'read_timeout' => null, // disable the inter-chunk timeout entirely
+],
+```
+
+This timeout has no effect on plain `application/json` responses.
+
+---
+
+### 7. `callTool()` / `readResource()` return `array`
+
+**What changed.** The return types on the contract tightened from `mixed` to concrete types:
+
+| Method | 1.x | 2.x |
+| --- | --- | --- |
+| `tools()` | (untyped) | `Collection` |
+| `resources()` | (untyped) | `Collection` |
+| `callTool()` | `mixed` | `array` |
+| `readResource()` | `mixed` | `array` |
+
+**Action.** None for the common case — both methods always returned arrays in practice. If you assigned `$result = $client->callTool(...)` to a variable typed as `mixed` and used it as a scalar, your code already had a latent bug; treat the return value as `array`.
+
+Both methods now also accept an optional third `?callable $onEvent` argument; existing call sites without it are unchanged.
+
+`callTool()` and `readResource()` called *without* a prior `connect()` now throw a `RuntimeException` with the message `"Call connect($serverName) before callTool()."` (or `…readResource().`). 1.x leaked a `TypeError` from an uninitialized typed property in the same situation.
+
+---
+
+### 8. Interface signatures tightened
+
+**Only relevant if you implement `Redberry\MCPClient\Core\Transporters\Transporter` or `Redberry\MCPClient\Contracts\MCPClient` in your own code.**
+
+#### `Transporter::request()`
+
+Added a third optional parameter:
+
+```php
+// 1.x
+public function request(string $action, array $params = []): array;
+
+// 2.x
+public function request(string $action, array $params = [], ?callable $onEvent = null): array;
+```
+
+If your transport doesn't stream, accept the parameter and ignore it — match the contract exactly. PHP's interface compatibility check requires the signature to align.
+
+#### `Contracts\MCPClient`
+
+```php
+// 1.x
+public function tools();
+public function resources();
+public function callTool(string $toolName, mixed $params = []): mixed;
+public function readResource(string $uri): mixed;
+
+// 2.x
+public function tools(): Collection;
+public function resources(): Collection;
+public function callTool(string $toolName, mixed $params = [], ?callable $onEvent = null): array;
+public function readResource(string $uri, ?callable $onEvent = null): array;
+```
+
+Update return types and add the `?callable $onEvent` parameter to bring your implementation in line.
+
+---
+
+### After upgrading
+
+1. Bump your `composer.json` constraint: `"redberry/mcp-client-laravel": "^2.0"`.
+2. Run `composer update redberry/mcp-client-laravel`.
+3. Run your test suite. The most likely surface for regressions is multi-server code paths (section 1) and any STDIO worker that depended on the old kill-timer behavior (section 4).
+4. If you publish `config/mcp-client.php`, diff it against the 2.x default to pick up the new `read_timeout`, `max_session_retries`, `request_timeout`, `process_timeout`, and `inherit_env` keys. None are required — defaults are backwards-compatible apart from the changes called out in sections 4–6.
+
+If you hit something this guide doesn't cover, please open an issue at <https://github.com/RedberryProducts/mcp-client-laravel/issues>.


### PR DESCRIPTION
## Summary

Prepares the package for a clean `v2.0.0` cut on top of the work merged in #48–#53. No code changes — documentation only.

- **`UPGRADE.md` (new).** Step-by-step `1.x → 2.x` migration guide with before/after recipes for the seven user-visible breaking changes (immutable `connect`, singleton binding, contract alias, STDIO `timeout` split, env inheritance, SSE read timeout, tightened return types) and an interface-implementer section for third-party transports.
- **`README.md` rewrite.** Declarative, task-shaped headings; per-transport option tables; a `> Note.` callout for the `php artisan serve` STDIO incompatibility; documents every 2.x option (`read_timeout`, `max_session_retries`, `request_timeout`, `process_timeout`, `inherit_env`) inline; fixes two malformed Markdown links.
- **`ARCHITECTURE.md` refresh.** Drops the "Known gaps" sections that all describe shipped work (P0–P5); fixes STDIO lifecycle diagram defaults (`100ms` / `20ms` / `30s`) and the `notifications/initialized` name; updates Configuration code blocks to the 2.x key set; tightens the public-API table to `: array` returns.
- **`ROADMAP.md` update.** Adds P8 (STDIO robustness), P9 (HTTP `error.message` defensive parse), and P10 (Collection match key) to Completed with their PR links.
- **`CHANGELOG.md` cut.** Promotes `## Unreleased` to `## v2.0.0 - 2026-05-05`.

## Test plan

- [x] `bin/check` (Pint + PHPStan + Pest) passes locally — 133 tests, 362 assertions
- [ ] CI green on the branch (Pint, PHPStan, run-tests across PHP 8.3/8.4/8.5 × Laravel 11/12/13)
- [ ] Skim `UPGRADE.md` against the actual `v1.1.0..HEAD` diff to confirm no breaking change is missing
- [ ] After merge: `git tag -a v2.0.0 -m "v2.0.0"` from `main` and `git push origin v2.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)