### PR TITLE
feat: support guzzle 8 alongside guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.3||^8.4||^8.5",
-        "guzzlehttp/guzzle": "^7.5",
+        "guzzlehttp/guzzle": "^7.5||^8.0",
         "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "psr/http-message": "^1.1||^2.0",
         "spatie/laravel-package-tools": "^1.16"

--- a/tests/Transporter/HttpTransporterTest.php
+++ b/tests/Transporter/HttpTransporterTest.php
@@ -2,7 +2,7 @@
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
@@ -321,7 +321,7 @@ describe('HttpTransporter', function () {
                     isset($options['timeout']) &&
                     $options['timeout'] === 30;
             }))
-            ->andThrow(new TransferException('Network failure', 502));
+            ->andThrow(new ServerException('Network failure', new Request('POST', ''), new Response(502)));
 
         $this->expectException(TransporterRequestException::class);
         $this->expectExceptionMessage('HTTP error for networkFailure: Network failure');
@@ -462,7 +462,7 @@ SSE;
 
         $mockClient->shouldReceive('request')
             ->once()
-            ->andThrow(new TransferException('init refused', 503));
+            ->andThrow(new ServerException('init refused', new Request('POST', ''), new Response(503)));
 
         $this->expectException(TransporterRequestException::class);
         $this->expectExceptionMessage('HTTP error during initialize handshake: init refused');
@@ -681,7 +681,7 @@ SSE;
             ->andReturn($initResp);
         $mockClient->shouldReceive('request')->once()
             ->with('POST', '', Mockery::on(fn ($opts) => ($opts['json']['method'] ?? null) === 'notifications/initialized'))
-            ->andThrow(new TransferException('notify refused', 503));
+            ->andThrow(new ServerException('notify refused', new Request('POST', ''), new Response(503)));
 
         expect(fn () => $transporter->request('first'))
             ->toThrow(TransporterRequestException::class, 'HTTP error sending notifications/initialized');


### PR DESCRIPTION
Supersedes #57. Dependabot proposed replacing `^7.5` with `^8.0`; that breaks Laravel 11/12, which is why its CI failed:

```
Root composer.json requires laravel/framework 12.*
  -> laravel/framework requires guzzlehttp/guzzle ^7.8.2
     but it conflicts with your root composer.json require (^8.0).
```

Widening is the correct move instead. Current `laravel/framework` 13.x requires `guzzlehttp/guzzle ^7.8.2 || ^8.0`, so an L13 app that resolves guzzle 8 **cannot install this package today** — `^7.5` blocks it. `^7.5||^8.0` unblocks those apps while keeping L10–L12 working.

## Changes

- `composer.json`: `"guzzlehttp/guzzle": "^7.5||^8.0"`
- `tests/Transporter/HttpTransporterTest.php`: three call sites built `new TransferException($message, 502)`, and guzzle 8 redefines argument 2 of that constructor as the `RequestInterface`. Swapped for `ServerException($message, new Request(...), new Response(502))` — the same 3-arg shape the file already uses for `ClientException`, identical on both majors, and it still carries the status code that `expectExceptionCode()` asserts.

**No library code changed.** `HttpTransporter` only ever catches `GuzzleException` / `BadResponseException` and rewraps them in `TransporterRequestException`; it never constructs a Guzzle exception, so it was already compatible.

## Verification

Run locally against both majors:

| | Result |
|---|---|
| guzzle 7.15.3 | 133 passed (362 assertions) |
| guzzle 8.0.2 | 133 passed (362 assertions) |
| `pint --test` | passed |

CI covers the full matrix (PHP 8.3/8.4/8.5 × Laravel 11/12/13, prefer-lowest and prefer-stable), which is the real check that `prefer-lowest` still resolves guzzle 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6xyqEjTHSqz2CkQM1DDn2